### PR TITLE
Add list of derivable typeclasses

### DIFF
--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -109,23 +109,7 @@ Currently, the following type classes can be derived:
 Some type classes can be automatically solved by the PureScript Compiler without requiring you place a PureScript statement, like `derive instance`, in your source code.
 
 ``` purescript
-module SolvingIsSymbol where
-
-import Data.Symbol
-
-literalSymbol :: SProxy "literal"
-literalSymbol = SProxy
-
-libReflectSymbol :: forall s. IsSymbol s => SProxy s -> String
-libReflectSymbol = reflectSymbol
-
-main = do
-  let lit = libReflectSymbol literalSymbol
-  when (lit == "literal") (log "Done")
-```
-
-``` purescript
-foo :: forall t. Warn "Custom warning message" => t -> t
+foo :: forall t. (Warn "Custom warning message") => t -> t
 foo x = x
 ```
 

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -95,5 +95,9 @@ newtype Person = Person { name :: String, age :: Int }
 derive instance eqPerson :: Eq Person
 derive instance ordPerson :: Ord Person
 ```
-
-TODO: list derivable type classes
+Currently, the following type classes can be derived:
+- Generic
+- Eq
+- Ord
+- Functor
+- Newtype

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -131,7 +131,6 @@ foo x = x
 
 Currently, the following type classes can be automatically solved:
 
-- NamedInstance
 - Warn
 - [IsSymbol](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/1.0.0/docs/Type.Data.Symbol#t:IsSymbol)
 - [CompareSymbol](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/1.0.0/docs/Type.Data.Symbol#t:CompareSymbol)

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -96,8 +96,43 @@ derive instance eqPerson :: Eq Person
 derive instance ordPerson :: Ord Person
 ```
 Currently, the following type classes can be derived:
-- Generic
-- Eq
-- Ord
-- Functor
-- Newtype
+
+- [Data.Generic (class Generic)](https://pursuit.purescript.org/packages/purescript-generics/3.3.0/docs/Data.Generic#t:Generic)
+- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-generics-rep/4.1.0/docs/Data.Generic.Rep#t:Generic)
+- [Data.Eq (class Eq)](https://pursuit.purescript.org/packages/purescript-prelude/2.4.0/docs/Data.Eq#t:Eq)
+- [Data.Ord (class Ord)](https://pursuit.purescript.org/packages/purescript-prelude/2.4.0/docs/Data.Ord#t:Ord)
+- [Data.Functor (class Functor)](https://pursuit.purescript.org/packages/purescript-prelude/2.4.0/docs/Data.Functor#t:Functor)
+- [Data.Newtype (class Newtype)](https://pursuit.purescript.org/packages/purescript-newtype/1.3.0/docs/Data.Newtype#t:Newtype)
+
+## Compiler-Solvable Type Classes
+
+Some type classes can be automatically solved by the PureScript Compiler without requiring you place a PureScript statement, like `derive instance`, in your source code.
+
+``` purescript
+module SolvingIsSymbol where
+
+import Data.Symbol
+
+literalSymbol :: SProxy "literal"
+literalSymbol = SProxy
+
+libReflectSymbol :: forall s. IsSymbol s => SProxy s -> String
+libReflectSymbol = reflectSymbol
+
+main = do
+  let lit = libReflectSymbol literalSymbol
+  when (lit == "literal") (log "Done")
+```
+
+``` purescript
+foo :: forall t. Warn "Custom warning message" => t -> t
+foo x = x
+```
+
+Currently, the following type classes can be automatically solved:
+
+- NamedInstance
+- Warn
+- [IsSymbol](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/1.0.0/docs/Type.Data.Symbol#t:IsSymbol)
+- [CompareSymbol](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/1.0.0/docs/Type.Data.Symbol#t:CompareSymbol)
+- [AppendSymbol](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/1.0.0/docs/Type.Data.Symbol#t:AppendSymbol)


### PR DESCRIPTION
I created this list by looking at the compiler source, here:
https://github.com/purescript/purescript/blob/bdd8a09abbfc3a2f96a544d053cec1ea53b574fb/src/Language/PureScript/Sugar/TypeClasses/Deriving.hs#L67