### PR TITLE
Document syntax of case-expressions.

### DIFF
--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -392,6 +392,19 @@ Operator sections also work for functions used this way:
 fooBy2 = (_ `foo` 2)
 ```
 
+## Case expressions
+
+The `case` and `of` keywords are used to deconstruct values to create logic based on the value's constructors. You can match on multiple values by delimiting them with `,` in the head and cases.
+
+``` purescript
+f :: Maybe Boolean -> Either Boolean Boolean -> String
+f a b = case a, b of
+  Just true, Right true -> "Both true"
+  Just true, Left _ -> "Just is true"
+  Nothing, Right true -> "Right is true"
+  _, _ -> "Both are false"
+f (Just true) (Right true)
+```
 
 ## If-Then-Else expressions
 


### PR DESCRIPTION
I came to lookup how to delimit multiple values of a case-expression but didn't find it in the Syntax doc. It *is* in the [Pattern-Matching doc](https://github.com/purescript/documentation/blob/master/language/Pattern-Matching.md), however.

What are the rules for organizing language directory? I saw "Syntax" and figured case expressions would be in there because it's special syntax. Because everything in the language directory should be about syntax or core principles, should we reorganize this by deleting this file and putting it into other doc files, one for each section?