### PR TITLE
Haskell Differences: Operator Sections

### DIFF
--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -242,6 +242,22 @@ apply f x = f x
 infixr 0 apply as $
 ```
 
+## Operator Sections
+
+In Haskell, there is syntactic sugar to partially apply infix operators.
+
+```haskell
+(2 ^) -- desugars to `(^) 2`, or `\x -> x ^ 2`
+(^ 2) -- desugars to `flip (^) 2`, or `\x -> 2 ^ 
+```
+
+In PureScript, you can use partial application notation, instead. (Operator sections were removed in version 0.9.)
+
+```purescript
+(2 ^ _)
+(_ ^ 2)
+```
+
 ## Extensions
 
 The PureScript compiler does not support GHC-like language extensions. However, there are some "built-in" language features that are equivalent (or at least similar) to a number of GHC extensions. These currently are:

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -251,7 +251,7 @@ In Haskell, there is syntactic sugar to partially apply infix operators.
 (^ 2) -- desugars to `flip (^) 2`, or `\x -> 2 ^ x`
 ```
 
-In PureScript, you can use partial application notation, instead. (Operator sections were removed in version 0.9.)
+In PureScript, you can do the same using partial application notation.
 
 ```purescript
 (2 ^ _)

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -251,7 +251,7 @@ In Haskell, there is syntactic sugar to partially apply infix operators.
 (^ 2) -- desugars to `flip (^) 2`, or `\x -> 2 ^ x`
 ```
 
-In PureScript, you can do the same using partial application notation.
+In PureScript, operator sections look a little bit different.
 
 ```purescript
 (2 ^ _)

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -248,7 +248,7 @@ In Haskell, there is syntactic sugar to partially apply infix operators.
 
 ```haskell
 (2 ^) -- desugars to `(^) 2`, or `\x -> x ^ 2`
-(^ 2) -- desugars to `flip (^) 2`, or `\x -> 2 ^ 
+(^ 2) -- desugars to `flip (^) 2`, or `\x -> 2 ^ x`
 ```
 
 In PureScript, you can use partial application notation, instead. (Operator sections were removed in version 0.9.)


### PR DESCRIPTION
A small gotcha for me as I've started experimenting.

I do wish deprecated features had compiler errors :) Took me a bit of sleuthing to track this down!