### PR TITLE
Explained TypeSynonymInstance error

### DIFF
--- a/errors/TypeSynonymInstance.md
+++ b/errors/TypeSynonymInstance.md
@@ -20,7 +20,7 @@ Since every value that structually matches the type synonym could be considered 
 
 ## Fix
 
-A [newtype](../language/Types.md#newtypes) declaration generates a brand new type instead of introducing a synonym for an existing type. However, the runtime representation is the same. Newtypes can have type class instances declared for them:
+A [newtype](../language/Types.md#newtypes) declaration generates a brand new type instead of introducing a synonym for an existing type. Newtypes can have type class instances declared for them:
 
 ```purescript
 newtype Mass = Mass Number

--- a/errors/TypeSynonymInstance.md
+++ b/errors/TypeSynonymInstance.md
@@ -20,7 +20,7 @@ Since every value that structually matches the type synonym could be considered 
 
 ## Fix
 
-If a type is wrapped in a [Newtype](https://github.com/purescript/documentation/blob/master/language/Types.md#newtypes) instead, it is considered a different type than the underlying type by the type checker. Newtypes can have type class instances declared for them:
+A [newtype](https://github.com/purescript/documentation/blob/master/language/Types.md#newtypes) declaration generates a brand new type; instead of introducing a synonym for an existing type. However, the runtime representation is the same. Newtypes can have type class instances declared for them:
 
 ```purescript
 newtype Mass = Mass Number

--- a/errors/TypeSynonymInstance.md
+++ b/errors/TypeSynonymInstance.md
@@ -14,17 +14,13 @@ instance showMass :: Show Mass where
 
 ## Cause
 
-*Type synonyms* are merely aliases (usually created to avoid verbose type annotations) and do not declare a new unique type. It is still possible to use the synonym and its equivalent type interchangeably:
+[Type synonyms](https://github.com/purescript/documentation/blob/master/language/Types.md#type-synonyms) are merely aliases (usually created to avoid verbose type annotations) and do not declare a new unique type. It is still possible to use the synonym and its equivalent type interchangeably.
 
-```purescript
-velocity = 123.456 :: Mass  -- oops
-```
-
-Since every value that structually matches the type synonym could be considered of the same type, it is not allowed to implement type classes based on type synonyms.
+Since every value that structually matches the type synonym could be considered of the same type, it is not allowed to implement [type classes](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md) based on type synonyms.
 
 ## Fix
 
-If a type is wrapped in a **newtype** instead, it becomes a different type than the underlying type. Newtypes can be used as type class instances:
+If a type is wrapped in a [Newtype](https://github.com/purescript/documentation/blob/master/language/Types.md#newtypes) instead, it is considered a different type than the underlying type by the type checker. Newtypes can have type class instances declared for them:
 
 ```purescript
 newtype Mass = Mass Number

--- a/errors/TypeSynonymInstance.md
+++ b/errors/TypeSynonymInstance.md
@@ -20,7 +20,7 @@ Since every value that structually matches the type synonym could be considered 
 
 ## Fix
 
-A [newtype](https://github.com/purescript/documentation/blob/master/language/Types.md#newtypes) declaration generates a brand new type; instead of introducing a synonym for an existing type. However, the runtime representation is the same. Newtypes can have type class instances declared for them:
+A [newtype](https://github.com/purescript/documentation/blob/master/language/Types.md#newtypes) declaration generates a brand new type instead of introducing a synonym for an existing type. However, the runtime representation is the same. Newtypes can have type class instances declared for them:
 
 ```purescript
 newtype Mass = Mass Number

--- a/errors/TypeSynonymInstance.md
+++ b/errors/TypeSynonymInstance.md
@@ -3,19 +3,43 @@
 ## Example
 
 ```purescript
-module ShortFailingExample where
+module TypeSynonymInstanceError where
+import Prelude
 
-...
+type Mass = Number
+
+instance showMass :: Show Mass where
+  show mass = "Mass: " <> show mass <> "kg"
 ```
 
 ## Cause
 
-Explain why a user might see this error.
+*Type synonyms* are merely aliases (usually created to avoid verbose type annotations) and do not declare a new unique type. It is still possible to use the synonym and its equivalent type interchangeably:
+
+```purescript
+velocity = 123.456 :: Mass  -- oops
+```
+
+Since every value that structually matches the type synonym could be considered of the same type, it is not allowed to implement type classes based on type synonyms.
 
 ## Fix
 
-- Suggest possible solutions.
+If a type is wrapped in a **newtype** instead, it becomes a different type than the underlying type. Newtypes can be used as type class instances:
+
+```purescript
+newtype Mass = Mass Number
+
+instance showMass :: Show Mass where
+  show (Mass mass) = "Mass: " <> show mass <> "kg"
+```
 
 ## Notes
 
-- Additional notes.
+The same error occurs when the aliased type is a record:
+
+```purescript
+type Point = { x :: Number, y :: Number }
+
+instance showPoint :: Show Point where
+  show p = "Point " <> show p.x <> ", " <> show p.y
+```

--- a/errors/TypeSynonymInstance.md
+++ b/errors/TypeSynonymInstance.md
@@ -14,13 +14,13 @@ instance showMass :: Show Mass where
 
 ## Cause
 
-[Type synonyms](https://github.com/purescript/documentation/blob/master/language/Types.md#type-synonyms) are merely aliases (usually created to avoid verbose type annotations) and do not declare a new unique type. It is still possible to use the synonym and its equivalent type interchangeably.
+[Type synonyms](../language/Types.md#type-synonyms) are merely aliases (usually created to avoid verbose type annotations) and do not declare a new unique type. It is still possible to use the synonym and its equivalent type interchangeably.
 
-Since every value that structually matches the type synonym could be considered of the same type, it is not allowed to implement [type classes](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md) based on type synonyms.
+Since every value that structually matches the type synonym could be considered of the same type, it is not allowed to implement [type classes](../language/Type-Classes.md) based on type synonyms.
 
 ## Fix
 
-A [newtype](https://github.com/purescript/documentation/blob/master/language/Types.md#newtypes) declaration generates a brand new type instead of introducing a synonym for an existing type. However, the runtime representation is the same. Newtypes can have type class instances declared for them:
+A [newtype](../language/Types.md#newtypes) declaration generates a brand new type instead of introducing a synonym for an existing type. However, the runtime representation is the same. Newtypes can have type class instances declared for them:
 
 ```purescript
 newtype Mass = Mass Number


### PR DESCRIPTION
Motivated by http://stackoverflow.com/questions/43344447/type-class-instances-for-type-synonyms-are-disallowed
Feedback is very much welcome!