### PR TITLE
Small fixes for `let` and `do` in Syntax.md

### DIFF
--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -402,7 +402,7 @@ conditional = if 2 > 1 then "ok" else "oops"
 
 ## Let and where bindings
 
-The `let` keyword defines a collection of local declarations, which may be mutually recursive, and which may include type declarations:
+The `let` keyword introduces a collection of local declarations, which may be mutually recursive, and which may include type declarations:
 
 ``` purescript
 factorial :: Int -> Int

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -402,7 +402,7 @@ conditional = if 2 > 1 then "ok" else "oops"
 
 ## Let and where bindings
 
-The `let` keyword creates an expression with local bindings, which may be mutually recursive, and which may include type declarations:
+The let keyword introduces a collection of local declarations, which may be mutually recursive, and which may include type declarations:
 
 ``` purescript
 factorial :: Int -> Int
@@ -415,7 +415,7 @@ factorial =
     go 1
 ```
 
-The `where` keyword can be used at the end of a value declaration to set up bindings that are visible throughout that value:
+The where keyword can also be used to introduce local declarations at the end of a value declaration:
 
 ``` purescript
 factorial :: Int -> Int

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -402,7 +402,7 @@ conditional = if 2 > 1 then "ok" else "oops"
 
 ## Let and where bindings
 
-`let` expressions introduce a list of local declarations, which may be mutually recursive, and which may include type declarations:
+`let` expressions encompass a list of local declarations, which may be mutually recursive, and which may include type declarations:
 
 ``` purescript
 factorial :: Int -> Int

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -402,7 +402,7 @@ conditional = if 2 > 1 then "ok" else "oops"
 
 ## Let and where bindings
 
-The let keyword introduces a collection of local declarations, which may be mutually recursive, and which may include type declarations:
+The `let` keyword introduces a collection of local declarations, which may be mutually recursive, and which may include type declarations:
 
 ``` purescript
 factorial :: Int -> Int
@@ -415,7 +415,7 @@ factorial =
     go 1
 ```
 
-The where keyword can also be used to introduce local declarations at the end of a value declaration:
+The `where` keyword can also be used to introduce local declarations at the end of a value declaration:
 
 ``` purescript
 factorial :: Int -> Int

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -415,7 +415,7 @@ factorial =
     go 1
 ```
 
-`where` clauses can be added at the end of a function declaration, and allow to bind variables that are visible within the surrounding function context:
+`where` clauses can be added at the end of a function declaration, and allow to bind variables that are visible throughout the function:
 
 ``` purescript
 factorial :: Int -> Int

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -402,7 +402,7 @@ conditional = if 2 > 1 then "ok" else "oops"
 
 ## Let and where bindings
 
-The `let` keyword introduces a collection of local declarations, which may be mutually recursive, and which may include type declarations:
+`let` expressions introduce a list of local declarations, which may be mutually recursive, and which may include type declarations:
 
 ``` purescript
 factorial :: Int -> Int
@@ -415,7 +415,7 @@ factorial =
     go 1
 ```
 
-The `where` keyword can also be used to introduce local declarations at the end of a value declaration:
+`where` clauses can be added at the end of a function declaration, and allow to bind variables that are visible within the surrounding function context:
 
 ``` purescript
 factorial :: Int -> Int

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -122,7 +122,7 @@ Numeric literals can be integers (type `Int`) or floating point numbers (type `N
 ``` purescript
 16 :: Int
 0xF0 :: Int
-16.0 :: Float
+16.0 :: Number
 ```
 
 ### Strings

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -402,7 +402,7 @@ conditional = if 2 > 1 then "ok" else "oops"
 
 ## Let and where bindings
 
-`let` expressions encompass a list of local declarations, which may be mutually recursive, and which may include type declarations:
+The `let` keyword creates an expression with local bindings, which may be mutually recursive, and which may include type declarations:
 
 ``` purescript
 factorial :: Int -> Int
@@ -415,7 +415,7 @@ factorial =
     go 1
 ```
 
-`where` clauses can be added at the end of a function declaration, and allow to bind variables that are visible throughout the function:
+The `where` keyword can be used at the end of a value declaration to set up bindings that are visible throughout that value:
 
 ``` purescript
 factorial :: Int -> Int


### PR DESCRIPTION
Small fixes in the let and do documentation.