### PR TITLE
Move lua-purescript to stale

### DIFF
--- a/ecosystem/Alternate-backends.md
+++ b/ecosystem/Alternate-backends.md
@@ -11,7 +11,6 @@ There are various alternatives to `psc`'s default JavaScript backend:
 
 | source code                                                                             | PS version | Target        | 
 |:----------------------------------------------------------------------------------------|:-----------|:--------------|
-| [lua-purescript/purescript](https://github.com/lua-purescript/purescript)               | 0.9.1.0    | Lua           |
 | [andyarvanitis/purescript-clojure](https://github.com/andyarvanitis/purescript-clojure) |            | Clojure (JVM) |
 | [PyreScript](https://github.com/joneshf/pyrescript)                                     | 0.9.1      | Python        |
 | [epost/psc-query](https://github.com/epost/psc-query)                                   | 0.7.3.0    | Datalog       |
@@ -21,6 +20,7 @@ There are various alternatives to `psc`'s default JavaScript backend:
 
 | source code                                                                           | PS version | Target        |
 |:--------------------------------------------------------------------------------------|:-----------|:--------------|
+| [lua-purescript/purescript](https://github.com/lua-purescript/purescript)             | 0.9.1.0    | Lua           |
 | [slamdata/truffled-purescript](https://github.com/slamdata/truffled-purescript)       | 0.7.5.x    | Truffle (JVM) |
 | [osa1/psc-lua](https://github.com/osa1/psc-lua)                                       | 0.5.x      | Lua           |
 | [Gabriel439/Purescript-to-Python](https://github.com/Gabriel439/Purescript-to-Python) |            | Python        |


### PR DESCRIPTION
It is unlikely that I will pull in the latest changes any time soon, so I'm officially calling it stale.
If I ever get the urge to deal with it again, I will probably redo it from scratch with CoreFN or, if it'll be available, the imperative core.