### PR TITLE
Modernize some documentation with syntax additions and details

### DIFF
--- a/language/FFI.md
+++ b/language/FFI.md
@@ -31,15 +31,15 @@ Importing Types
 To declare a new abstract type (with no constructors), use `foreign import data` and provide the kind:
 
 ```purescript
-foreign import data DOMElement :: *
+foreign import data DOMElement :: Type
 
 foreign import document :: {
   createElement :: String -> DOMElement
 }
 ```
 
-When declaring types in this way, you may declare your type to have any kind, not just `*`. For example, to declare a row of effects:
+When declaring types in this way, you may declare your type to have any kind, not just `Type`. For example, to declare a row of effects:
 
 ```purescript
-foreign import data MyRow :: # !
+foreign import data MyRow :: # Effect
 ```

--- a/language/Modules.md
+++ b/language/Modules.md
@@ -26,20 +26,20 @@ module B where
 import A (runFoo)
 ```
 
-Values, type constructors, data constructors, and type classes can all be explicitly imported. A type constructor can be followed by a list of associated data constructors to import in parentheses. A double dot (`..`) can be used to import all data constructors for a given type constructor:
+Values, operators (wrapped in parentheses), type constructors, data constructors, and type classes can all be explicitly imported. A type constructor can be followed by a list of associated data constructors to import in parentheses. A double dot (`..`) can be used to import all data constructors for a given type constructor:
 
 ```purescript
 module B where
 
-import A (runFoo, Foo(..), Bar(Bar))
+import A (runFoo, (.~), Foo(..), Bar(Bar))
 ```
 
-Type classes are imported using the `class` keyword:
+Type classes are imported using the `class` keyword, kinds with `kind`:
 
 ```purescript
 module B where
 
-import A (class Fab)
+import A (class Fab, kind Effect)
 ```
 
 ### Hiding imports
@@ -59,15 +59,32 @@ Modules can also be imported qualified, which means that their names will not be
 
 ```purescript
 module Main where
-  
+
 import Data.Array as Array
-  
+
 null = ...
 
 test = Array.null [1, 2, 3]
 ```
-  
+
 Here, the name ``null`` would ordinarily conflict with ``null`` from ``Data.Array``, but the qualified import solves this problem. ``Data.Array.null`` can be referenced using ``Array.null`` instead.
+
+Operators can also be referenced this way:
+```purescript
+test' = Array.null ([1, 2, 3] Array.\\ [1, 2, 3])
+```
+
+Modules can be merged under the same name, but it is best to use explicit imports to avoid conflicts, in case modules would want to import the same name:
+
+```purescript
+module Main where
+
+import Data.String.Regex (split) as Re
+import Data.String.Regex.Flags (global) as Re
+import Data.String.Regex.Unsafe (unsafeRegex) as Re
+
+split = Re.split (Re.unsafeRegex "[,;:.]\\s+" Re.global)
+```
 
 ## Module Exports
 
@@ -93,6 +110,15 @@ Imported modules can be re-exported in their entirety:
 module A (module B) where
 
 import B
+```
+
+Qualified and explicit imports can be used also:
+
+```purescript
+module A (module MoreExports) where
+
+import A.Util (useful, usefulFn) as MoreExports
+import A.Type (ADatatype(..)) as MoreExports
 ```
 
 When re-exporting other modules, all local values and types can also be exported by specifying the module itself as an export:

--- a/language/Pattern-Matching.md
+++ b/language/Pattern-Matching.md
@@ -23,17 +23,17 @@ Patterns can also be used when introducing functions. For example:
 example x y z = x * y + z
 ```
 
-The following pattern types are supported:
+The following forms can be used for matching:
 
-- Wildcard pattern
+- Wildcard patterns
 - Literal patterns
-- Variable pattern
+- Variable patterns
 - Array patterns
 - Constructor patterns
 - Record patterns
 - Named patterns
-- Guards
-- Pattern guards
+
+Guards and pattern guards are also supported.
 
 The exhaustivity checker will introduce a `Partial` constraint for any pattern which is not exhaustive.
 By default, patterns must be exhaustive, since this `Partial` constraint will not be satisfied. The error can be silenced, however, by adding a local `Partial` constraint to your function.

--- a/language/Records.md
+++ b/language/Records.md
@@ -24,9 +24,9 @@ Fields of records can be accessed using a dot, followed by the label of the fiel
 
 `{ ... }` is just syntactic sugar for the `Record` type constructor, so `{ language ::  String }` is the same as `Record ( language :: String )`.
 
-The Record type constructor is parameterized by a row of types. In kind notation, `Record` has kind `# * -> *`. That is, it takes a row of types to a type.
+The Record type constructor is parameterized by a row of types. In kind notation, `Record` has kind `# Type -> Type`. That is, it takes a row of types to a type.
 
-`( language :: String )` denotes a row of types (something of kind `# *`), so it can be passed to `Record` to construct a type, namely `Record ( language :: String )`.
+`( language :: String )` denotes a row of types (something of kind `# Type`), so it can be passed to `Record` to construct a type, namely `Record ( language :: String )`.
 
 ## Extending Records
 
@@ -42,7 +42,7 @@ that can then be extended like:
 type Language = Lang ( country :: String )
 ```
 
-The `Language` type synonym would then be equivalent to `{ language :: String, country :: String }`.
+The `Language` type synonym would then be equivalent to `{ language :: String, country :: String }`. Note that parentheses must be used for the extension, since `l` has to be a row kind not a record type.
 
 ## Wildcards
 

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -234,18 +234,37 @@ This is equivalent to:
 \rec -> rec.propertyName
 ```
 
+These work with any number of levels:
+
+``` purescript
+_.nested.property.name
+```
+
 ### Record Updates
 
 Properties on records can be updated using the following syntax:
 
 ``` purescript
-rec { key1 = value1, ..., keyN = valueN }
+rec { key1 = value1, ..., keyN = valueN, nestedKey { subKey = value, ... } }
 ```
+
+Some or all of the keys may be updated at once, and records inside of records can also be updated.
 
 For example, the following function increments the `foo` property on its argument:
 
 ``` purescript
 \rec -> rec { foo = rec.foo + 1 }
+```
+
+[Nested record updates](https://liamgoodacre.github.io/purescript/records/2017/01/29/nested-record-updates.html) look like this:
+
+``` purescript
+r = { val: -1
+    , level1: { val: -1
+              , level2: { val: -1 }
+              }
+    }
+r' = r { level1 { val = 1 } }
 ```
 
 Wildcards can also be used in updates to produce a partially applied update:

--- a/language/Types.md
+++ b/language/Types.md
@@ -92,7 +92,7 @@ var add = function(x) {
         return x + y;
     };
 };
--- Or with ES6 arrow functions
+// Or with ES6 arrow functions
 var add = x => y => x + y;
 ```
 

--- a/language/Types.md
+++ b/language/Types.md
@@ -179,7 +179,7 @@ To denote an open row (i.e. one which may unify with another row to add new fiel
 
 ## Type Synonyms
 
-For convenience, it is possible to declare a synonym for a type using the ``type`` keyword. Type synonyms can include type arguments but [cannot be partially applied](https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md#partiallyappliedsynonym-error). Type synonyms can be built with any other types but [cannot refer to each other in a cycle](https://github.com/purescript/documentation/blob/master/errors/CycleInTypeSynonym.md#cycleintypesynonym-error).
+For convenience, it is possible to declare a synonym for a type using the ``type`` keyword. Type synonyms can include type arguments but [cannot be partially applied](../errors/PartiallyAppliedSynonym.md#partiallyappliedsynonym-error). Type synonyms can be built with any other types but [cannot refer to each other in a cycle](../errors/CycleInTypeSynonym.md#cycleintypesynonym-error).
 
 For example:
 
@@ -218,7 +218,7 @@ type RandomConsoleEffects eff = ( random :: RANDOM, console :: CONSOLE | eff )
 type RandomConsoleEffect = RandomConsoleEffects ()
 ```
 
-Unlike newtypes, type synonyms are merely aliases and cannot be distinguished from usages of their expansion. Because of this they cannot be used to declare a type class instance. For more see [``TypeSynonymInstance`` Error](https://github.com/purescript/documentation/blob/master/errors/TypeSynonymInstance.md#typesynonyminstance-error).
+Unlike newtypes, type synonyms are merely aliases and cannot be distinguished from usages of their expansion. Because of this they cannot be used to declare a type class instance. For more see [``TypeSynonymInstance`` Error](../errors/TypeSynonymInstance.md#typesynonyminstance-error).
 
 ## Constrained Types
 

--- a/language/Types.md
+++ b/language/Types.md
@@ -74,31 +74,7 @@ instance showPercentage :: Show Percentage where
 
 ## Functions
 
-Functions in PureScript are like their Javascript counterparts, but always have exactly one argument at the type level. Writing multiple arguments is shorthand for nested lambda functions. For example, the following are all equivalent:
-
-```purescript
-add :: Number -> Number -> Number
-add x y = x + y
-add = \x y -> x + y
-add = \x -> \y -> x + y
-add = (+)
-```
-
-And correspond to this in JavaScript:
-
-```javascript
-var add = function(x) {
-    return function(y) {
-        return x + y;
-    };
-};
-// Or with ES6 arrow functions
-var add = x => y => x + y;
-```
-
-This is called currying and one of its benefits is partial application. For a guide on how it works in Haskell, not much different from PureScript, see [Currying on the Haskell wiki](https://wiki.haskell.org/Currying).
-
-However, since uncurried JavaScript functions can be more efficient to run, they are provided indirectly through the [purescript-functions](https://pursuit.purescript.org/packages/purescript-functions/) library. This is unnecessary in most cases and should **not** be used for APIs. For more information see [Functions of Multiple Arguments](http://www.purescript.org/learn/ffi/#functions-of-multiple-arguments).
+Functions in PureScript are like their Javascript counterparts, but always have exactly one argument.
 
 ## Polymorphic Types
 

--- a/language/Types.md
+++ b/language/Types.md
@@ -55,7 +55,7 @@ In the example, Foo is a tagged union type which has two constructors. Its first
 
 ## Newtypes
 
-Newtypes are like data types (which are introduced with the `data` keyword), but are restricted to a single constructor which contains a single argument. Newtypes are introduced with the `newtype` keyword::
+Newtypes are like data types (which are introduced with the `data` keyword), but are restricted to a single constructor which contains a single argument. Newtypes are introduced with the `newtype` keyword:
 
 ```purescript
 newtype Percentage = Percentage Number
@@ -74,7 +74,16 @@ instance showPercentage :: Show Percentage where
 
 ## Functions
 
-Functions in PureScript are like their Javascript counterparts, but always have exactly one argument.
+Functions in PureScript are like their Javascript counterparts, but always have exactly one argument. Function declarations and lambdas (anonymous functions) with multiple arguments are shorthand for curried lambda abstractions. For example, the following are all equivalent:
+
+```purescript
+add x y = x + y
+add = \x y -> x + y
+add = \x -> \y -> x + y
+add = (+)
+```
+
+Despite this overwhelming convention, uncurried JavaScript functions are can be used through the [purescript-functions](https://pursuit.purescript.org/packages/purescript-functions/) library. For more information see [The Foreign Function Interface](http://www.purescript.org/learn/ffi/).
 
 ## Polymorphic Types
 
@@ -86,7 +95,7 @@ identity x = x
 
 ``identity`` is inferred to have (polymorphic) type ``forall t0. t0 -> t0``. This means that for any type ``t0``, ``identity`` can be given a value of type ``t0`` and will give back a value of the same type.
 
-A type annotation can also be provided::
+A type annotation can also be provided:
 
 ```purescript
 identity :: forall a. a -> a
@@ -97,19 +106,19 @@ identity x = x
 
 Polymorphism is not limited to abstracting over types. Values may also be polymorphic in types with other kinds, such as rows or effects (see "Kind System").
 
-For example, the following function accesses two properties on a record::
+For example, the following function accesses two properties on a record:
 
 ```purescript
 addProps o = o.foo + o.bar + 1
 ```
 
-The inferred type of ``addProps`` is::
+The inferred type of ``addProps`` is:
 
 ```purescript
-forall r. { foo :: Int, bar :: Int | r } -> Number
+forall r. { foo :: Int, bar :: Int | r } -> Int
 ```
 
-Here, the type variable ``r`` has kind ``# *`` - it represents a `row` of `types`. It can be instantiated with any row of named types.
+Here, the type variable ``r`` has kind ``# Type`` - it represents a row of types. It can be instantiated with any row of named types.
 
 In other words, ``addProps`` accepts any record which has properties ``foo`` and ``bar``, and *any other record properties*.
 
@@ -133,7 +142,7 @@ It is also possible for the ``forall`` quantifier to appear on the left of a fun
 
 In most cases, a type annotation is necessary when using this feature.
 
-As an example, we can pass a polymorphic function as an argument to another function::
+As an example, we can pass a polymorphic function as an argument to another function:
 
 ```purescript
 poly :: (forall a. a -> a) -> Boolean
@@ -142,7 +151,7 @@ poly f = (f 0 < 1) == f true
 
 Notice that the polymorphic function's type argument is instantiated to both ``Number`` and ``Boolean``.
 
-An argument to ``poly`` must indeed be polymorphic. For example, the following fails::
+An argument to ``poly`` must indeed be polymorphic. For example, the following fails:
 
 ```purescript
 test = poly (\n -> n + 1)
@@ -152,39 +161,64 @@ since the skolemized type variable ``a`` does not unify with ``Int``.
 
 ## Rows
 
-A row of types represents an unordered collection of named types without duplicates.
+A row of types represents an unordered collection of named types. Duplicate labels are allowed but are distinct.
 
-Rows have kind ``# k`` for some kind ``k``, and so values do not have types which are rows. Rather, rows can be used in type signatures to define record types or other type where labelled, unordered types are useful.
+Rows are not of kind ``Type``: they have kind ``# k`` for some kind ``k``, and so values do not have types which are rows. Rather, rows can be used in type signatures to define record types or other type where labelled, unordered types are useful.
 
-To denote a closed row, separate the fields with commas, with each label separated from its type with a double colon::
+To denote a closed row, separate the fields with commas, with each label separated from its type with a double colon:
 
 ```purescript
-(name :: String, age :: Number)
+( name :: String, age :: Number )
 ```
 
-To denote an open row (i.e. one which may unify with another row to add new fields), separate the specified terms from a row variable by a pipe::
+To denote an open row (i.e. one which may unify with another row to add new fields), separate the specified terms from a row variable by a pipe:
 
 ```purescript
-(name :: String, age :: Number | r)
+( name :: String, age :: Number | r )
 ```
 
 ## Type Synonyms
 
-For convenience, it is possible to declare a synonym for a type using the ``type`` keyword. Type synonyms can include type arguments.
+For convenience, it is possible to declare a synonym for a type using the ``type`` keyword. Type synonyms can include type arguments but [cannot be partially applied](https://github.com/purescript/documentation/blob/master/errors/PartiallyAppliedSynonym.md#partiallyappliedsynonym-error). Type synonyms can be built with any other types but [cannot refer to each other in a cycle](https://github.com/purescript/documentation/blob/master/errors/CycleInTypeSynonym.md#cycleintypesynonym-error).
 
-For example::
+For example:
 
 ```purescript
+-- Create an alias for a record with two fields
 type Foo = { foo :: Number, bar :: Number }
 
+-- Add the two fields together, since they are Numbers
 addFoo :: Foo -> Number
 addFoo o = o.foo + o.bar
 
+-- Create an alias for a polymorphic record with the same shape
 type Bar a = { foo :: a, bar :: a }
+-- Foo is now equivalent to Bar Number
 
+-- Apply the fields of any Bar to a function
 combineBar :: forall a b. (a -> a -> b) -> Bar a -> b
 combineBar f o = f o.foo o.bar
+
+-- Create an alias for a complex function type
+type Baz = Number -> Number -> Bar Number
+
+-- This function will take two arguments and return a record with double the value
+mkDoubledFoo :: Baz
+mkDoubledFoo foo bar = { foo: 2.0*foo, bar: 2.0*bar }
+
+-- Build on our preious functions to double the values inside any Foo
+-- (Rembmer that Bar Number is the same as Foo)
+doubleFoo :: Foo -> Foo
+doubleFoo = combineBar mkDoubledFoo
+
+-- Define type synonyms to help write complex Effect rows
+-- This will accept further Effects to be added to the row
+type RandomConsoleEffects eff = ( random :: RANDOM, console :: CONSOLE | eff )
+-- This limits the Effects to just RANDOM and CONSOLE
+type RandomConsoleEffect = RandomConsoleEffects ()
 ```
+
+Unlike newtypes, type synonyms are merely aliases and cannot be distinguished from usages of their expansion. Because of this they cannot be used to declare a type class instance. For more see [``TypeSynonymInstance`` Error](https://github.com/purescript/documentation/blob/master/errors/TypeSynonymInstance.md#typesynonyminstance-error).
 
 ## Constrained Types
 
@@ -192,14 +226,23 @@ Polymorphic types may be predicated on one or more ``constraints``. See the chap
 
 ## Type Annotations
 
-Most types can be inferred (not including Rank N Types and constrained types), but annotations can optionally be provided using a double-colon::
+Most types can be inferred (not including Rank N Types and constrained types), but annotations can optionally be provided using a double-colon, either as a declaration or after an expression:
 
 ```purescript
-one = 1 :: Int
+-- Defined in Data.Semiring
+one :: forall a. (Semiring a) => a
 
--- Either of the following will type check, because the first is a more general form of the second
-x = one :: forall a. (Semiring a) => a
-x = one :: Int
+-- This can be constrained to just an Int, since Int is an instance of Semiring
+int1 :: Int
+int1 = one -- x = 1
+-- Or even a Number, which also provides a Semiring
+number1 = one :: Number -- y = 1.0
+-- Or its polymorphism can be kept, so it will work with any Semiring
+-- (This is the default if no annotation is given)
+semiring1 :: forall a. Semiring a => a
+semiring1 = one
+-- It can even be constrained by another type class
+equal1 = one :: forall a. Semiring a => Eq a => a
 ```
 
 ## Kind System
@@ -215,7 +258,7 @@ The kind system defines the following kinds:
 
 The kind ``# k`` of rows is used to classify labelled, unordered collections of types of kind ``k``.
 
-For example ``# *`` is the kind of rows of types, as used to define records, and ``# !`` is the kind of rows of effects, used to define the monad ``Eff`` of extensible effects.
+For example ``# Type`` is the kind of rows of types, as used to define records, and ``# Control.Monad.Eff.Effect`` is the kind of rows of effects, used to define the monad ``Control.Monad.Eff.Eff`` of extensible effects.
 
 ## Quantification
 

--- a/language/Types.md
+++ b/language/Types.md
@@ -74,16 +74,31 @@ instance showPercentage :: Show Percentage where
 
 ## Functions
 
-Functions in PureScript are like their Javascript counterparts, but always have exactly one argument. Function declarations and lambdas (anonymous functions) with multiple arguments are shorthand for curried lambda abstractions. For example, the following are all equivalent:
+Functions in PureScript are like their Javascript counterparts, but always have exactly one argument at the type level. Writing multiple arguments is shorthand for nested lambda functions. For example, the following are all equivalent:
 
 ```purescript
+add :: Number -> Number -> Number
 add x y = x + y
 add = \x y -> x + y
 add = \x -> \y -> x + y
 add = (+)
 ```
 
-Despite this overwhelming convention, uncurried JavaScript functions are can be used through the [purescript-functions](https://pursuit.purescript.org/packages/purescript-functions/) library. For more information see [The Foreign Function Interface](http://www.purescript.org/learn/ffi/).
+And correspond to this in JavaScript:
+
+```javascript
+var add = function(x) {
+    return function(y) {
+        return x + y;
+    };
+};
+-- Or with ES6 arrow functions
+var add = x => y => x + y;
+```
+
+This is called currying and one of its benefits is partial application. For a guide on how it works in Haskell, not much different from PureScript, see [Currying on the Haskell wiki](https://wiki.haskell.org/Currying).
+
+However, since uncurried JavaScript functions can be more efficient to run, they are provided indirectly through the [purescript-functions](https://pursuit.purescript.org/packages/purescript-functions/) library. This is unnecessary in most cases and should **not** be used for APIs. For more information see [Functions of Multiple Arguments](http://www.purescript.org/learn/ffi/#functions-of-multiple-arguments).
 
 ## Polymorphic Types
 
@@ -161,9 +176,9 @@ since the skolemized type variable ``a`` does not unify with ``Int``.
 
 ## Rows
 
-A row of types represents an unordered collection of named types. Duplicate labels are allowed but are distinct.
+A row of types represents an unordered collection of named types, with duplicates. Duplicate labels have their types collected together in order, as if in a ``NonEmptyList``. This means that, conceptually, a row can be thought of as a type-level ``Map Label (NonEmptyList Type)``.
 
-Rows are not of kind ``Type``: they have kind ``# k`` for some kind ``k``, and so values do not have types which are rows. Rather, rows can be used in type signatures to define record types or other type where labelled, unordered types are useful.
+Rows are not of kind ``Type``: they have kind ``# k`` for some kind ``k``, and so rows cannot exist as a value. Rather, rows can be used in type signatures to define record types or other type where labelled, unordered types are useful.
 
 To denote a closed row, separate the fields with commas, with each label separated from its type with a double colon:
 

--- a/language/Types.md
+++ b/language/Types.md
@@ -221,8 +221,8 @@ type Baz = Number -> Number -> Bar Number
 mkDoubledFoo :: Baz
 mkDoubledFoo foo bar = { foo: 2.0*foo, bar: 2.0*bar }
 
--- Build on our preious functions to double the values inside any Foo
--- (Rembmer that Bar Number is the same as Foo)
+-- Build on our previous functions to double the values inside any Foo
+-- (Remember that Bar Number is the same as Foo)
 doubleFoo :: Foo -> Foo
 doubleFoo = combineBar mkDoubledFoo
 


### PR DESCRIPTION
Is it better to be explicit with ``# Control.Monad.Eff.Effect`` or let the reader figure out that ``# Effect`` can be used after importing ``Control.Monad.Eff``?