### PR TITLE
Fix typo and missing markdown pipe escapes in guides/Common-Operators

### DIFF
--- a/guides/Common-Operators.md
+++ b/guides/Common-Operators.md
@@ -2,7 +2,7 @@
 
 Or, "what is the PureScript equivalent of \<X operator\> in JS?"
 
-Although the PureScript language defines no built-in operators, plenty are defined in the `Prelude` and other core libraries. This guide gives you a overview of these operators and the corresponding operators in JavaScript.
+Although the PureScript language defines no built-in operators, plenty are defined in the `Prelude` and other core libraries. This guide gives you an overview of these operators and the corresponding operators in JavaScript.
 
 ## JavaScript's unary operators
 
@@ -34,9 +34,9 @@ This means that the PureScript analogues to unary JavaScript operators (other th
 | `>`         | `>`                 | `Data.Ord`            | Greater than                             |
 | `>=`        | `>=`                | `Data.Ord`            | Greater than or equal                    |
 | `&&`        | `&&`                | `Data.HeytingAlgebra` | Boolean AND                              |
-| `||`        | `||`                | `Data.HeytingAlgebra` | Boolean OR                               |
+| `\|\|`      | `\|\|`              | `Data.HeytingAlgebra` | Boolean OR                               |
 | `&`         | `.&.`               | `Data.Int.Bits`       | Bitwise AND                              |
-| `|`         | `.|.`               | `Data.Int.Bits`       | Bitwise OR                               |
+| `\|`        | `.\|.`              | `Data.Int.Bits`       | Bitwise OR                               |
 | `^`         | `.^.`               | `Data.Int.Bits`       | Bitwise XOR                              |
 | `<<`        | `shl`               | `Data.Int.Bits`       | Shift Left                               |
 | `>>`        | `shr`               | `Data.Int.Bits`       | Shift Right                              |


### PR DESCRIPTION
Hey there,

This PR fixes two minor issues in `guides/Common-Operators.md`:

1. A typo with "a overview" instead of "an overview";

1. Operators with `|` characters not being rendered correctly since they're contained within a markdown table:

![screen shot 2017-07-06 at 10 57 07 pm](https://user-images.githubusercontent.com/3409214/27941853-d4ab3c02-62a0-11e7-9035-50b43af0780b.png)

Thanks!
