### PR TITLE
Update repl sessions to avoid obsolete 'let'

### DIFF
--- a/errors/CycleInDeclaration.md
+++ b/errors/CycleInDeclaration.md
@@ -5,7 +5,7 @@
 ```text
 $ pulp psci
 
-> let x = x
+> x = x
 Error found:
 at  line 1, column 5 - line 1, column 9
 

--- a/errors/KindsDoNotUnify.md
+++ b/errors/KindsDoNotUnify.md
@@ -4,7 +4,7 @@
 
 ```purescript
 > import Type.Proxy
-> let x = Proxy :: Proxy Array
+> x = Proxy :: Proxy Array
 Error found:
 in module $PSCI
 at line 1, column 5 - line 1, column 24

--- a/errors/NoInstanceFound.md
+++ b/errors/NoInstanceFound.md
@@ -53,7 +53,7 @@ The `NoInstanceFound` error can also occur when a pattern matching definition ha
 As an example of this situation, consider the following definition:
 
 ```
-> let f 0 = 0
+> f 0 = 0
 ```
 
 This function does not handle all possible inputs: it is undefined for all inputs other than zero. Such functions are called *partial* and the compiler will infer a `Partial` constraint:

--- a/errors/OverlappingArgNames.md
+++ b/errors/OverlappingArgNames.md
@@ -3,7 +3,7 @@
 ## Example
 
 ```purescript
-> let f x x = x
+> f x x = x
 Error found:
 in module $PSCI
 at line 1, column 5 - line 1, column 13

--- a/errors/ShadowedName.md
+++ b/errors/ShadowedName.md
@@ -3,9 +3,7 @@
 ## Example
 
 ```
-> let x =
-    let x = 1
-    in x
+> x = let x = 1 in x
 
 Warning 1 of 1:
 

--- a/errors/UnknownName.md
+++ b/errors/UnknownName.md
@@ -4,7 +4,7 @@
 
 ```
 > import Prelude
-> let bar x = y + 1
+> x = y + 1
 
 Error found:
 in module $PSCI

--- a/guides/PSCi.md
+++ b/guides/PSCi.md
@@ -40,9 +40,9 @@ Type expressions into the REPL to have them evaluated:
     > 3 + 4
     7
 
-Introduce bindings with `let`:
+Introduce bindings with `=`:
 
-    > let x = 4
+    > x = 4
     > x + 9
     13
 
@@ -57,14 +57,13 @@ You can also define data types, type classes, and type class instances (you may 
 Enter `:paste` (or `:p`) to enter multi-line (or "paste") mode. Terminate it with `Control-D` key.
 
 ```
-> import Prelude                                                                 
-> :paste                                                                         
-… let
-…     add :: Int -> Int -> Int
-…     add = \x y -> x + y      
+> import Prelude
+> :paste
+… add :: Int -> Int -> Int
+… add = \x y -> x + y
 > add 10 20
 > (^D)
-30                                             
+30
 ```
 
 [Demo](https://asciinema.org/a/0y56unmja6fqire01x20zb5xx)
@@ -82,7 +81,7 @@ You can install it using Bower as follows:
 For help getting started, visit http://wiki.purescript.org/PSCi
 ```
 
-The PureScript compiler suite (`psc`, `psci`, etc), unlike most compilers, does not ship with a standard library. In PureScript, even `Prelude` is a normal module, just like any other. Consequentially, `psci` requires a specific library to be installed in order to be able to evaluate terms in the REPL.
+The PureScript compiler suite (i.e. the executable `purs`), unlike most compilers, does not ship with a standard library. In PureScript, even `Prelude` is a normal module, just like any other. Consequentially, `psci` requires a specific library to be installed in order to be able to evaluate terms in the REPL.
 
 `purescript-psci-support` defines the `Eval` type class for this purpose. Instances of `Eval` are provided for `Show`able types, and for `Eff`, so that we can evaluate actions in the REPL. Library implementors might like to provide `Eval` instances for their own `Eff`-like types.
 

--- a/guides/QuickCheck.md
+++ b/guides/QuickCheck.md
@@ -84,17 +84,23 @@ Error: Test 1 failed:
 
 #### Example 1 - GCD Function
 
-Let's write an implementation of the _greatest common divisor_ function in PSCi (you will need to enable multiline mode by restarting PSCi with `--multi-line-mode`):
+Let's write an implementation of the _greatest common divisor_ function in PSCi.
+
+This function is easiest to enter in the multi-line input mode, so switch to
+that by entering `:paste` at the prompt:
 
 ```
-> let
-    gcd 0 n = n
-    gcd n 0 = n
-    gcd n m | n < 0 = gcd (-n) m
-    gcd n m | m < 0 = gcd n (-m)
-    gcd n m | n > m = gcd (n - m) m
-    gcd n m = gcd n (m - n)
+> :paste
+… gcd 0 n = n
+… gcd n 0 = n
+… gcd n m | n < 0 = gcd (-n) m
+… gcd n m | m < 0 = gcd n (-m)
+… gcd n m | n > m = gcd (n - m) m
+… gcd n m = gcd n (m - n)
+…
 ```
+
+After typing that in, press Control-D to finish the input.
 
 Now let's assert some basic properties that we expect to hold of the `gcd` function.
 
@@ -151,13 +157,11 @@ The first functor law says that if you map a function which does not modify its 
 
 ```
 > import Data.Array
-
-> let
-    firstFunctorLaw :: Array Int -> Boolean
-    firstFunctorLaw arr = map id arr == arr
-
+> :paste
+… firstFunctorLaw :: Array Int -> Boolean
+… firstFunctorLaw arr = map id arr == arr
+…
 > quickCheck firstFunctorLaw
-
 100/100 test(s) passed.
 unit
 ```
@@ -165,12 +169,11 @@ unit
 The second functor law says that mapping two functions over a structure one-by-one is equivalent to mapping their composition over the structure:
 
 ```
-> let
-    secondFunctorLaw :: (Int -> Int) -> (Int -> Int) -> Array Int -> Boolean
-    secondFunctorLaw f g arr = map f (map g arr) == map (f <<< g) arr
-
+> :paste
+… secondFunctorLaw :: (Int -> Int) -> (Int -> Int) -> Array Int -> Boolean
+… secondFunctorLaw f g arr = map f (map g arr) == map (f <<< g) arr
+…
 > quickCheck secondFunctorLaw
-
 100/100 test(s) passed.
 unit
 ```
@@ -190,12 +193,11 @@ Copy the contents of that file into `src/UnderscoreFFI.purs`, and reload PSCi wi
 The `UnderscoreFFI` module defines a wrapper for the `sortBy` function. Let's test that the function is idempotent:
 
 ```
-> let
-    sortIsIdempotent :: Array Int -> Boolean
-    sortIsIdempotent arr = sortBy id (sortBy id arr) == sortBy id arr
-
+> :paste
+… sortIsIdempotent :: Array Int -> Boolean
+… sortIsIdempotent arr = sortBy id (sortBy id arr) == sortBy id arr
+…
 > quickCheck sortIsIdempotent
-
 100/100 test(s) passed.
 unit
 ```
@@ -203,12 +205,11 @@ unit
 In fact, we don't need to sort by the identity function. Since QuickCheck supports higher-order functions, we can test with a randomly-generated sorting function:
 
 ```
-> let
-    sortIsIdempotent' :: (Int -> Int) -> [Int] -> Boolean
-    sortIsIdempotent' f arr = sortBy f (sortBy f arr) == sortBy f arr
-
+> :paste
+… sortIsIdempotent' :: (Int -> Int) -> Array Int -> Boolean
+… sortIsIdempotent' f arr = sortBy f (sortBy f arr) == sortBy f arr
+…
 > quickCheck sortIsIdempotent
-
 100/100 test(s) passed.
 unit
 ```


### PR DESCRIPTION
As of v11.0.0, local bindings in a repl session must be written without
a 'let', e.g. 'x = y'. Fixes #98