### PR TITLE
Explain rows in typeclass instances

### DIFF
--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -80,27 +80,50 @@ In fact, a type similar to this `AddInt` is provided in `Data.Monoid.Additive`, 
 
 For multi-parameter type classes, the orphan instance check requires that the instance is either in the same module as the class, or the same module as at least one of the types occurring in the instance. (TODO: example)
 
+## Kinds
+
+A typeclass's parameter can specify the Kind. If it doesn't specify the type's Kind, it can be inferred by methods in the class.
+
+``` purescript
+class A a
+-- `a` is kind `Type`
+class B (b :: Type)
+-- `b` is kind `Type`
+class C c
+  f :: forall a b. (a -> b) -> c a -> c b
+-- `c` is kind `Type -> Type`
+class D (d :: Type -> Type)
+-- `d` is kind `Type -> Type`
+class E (e :: # Type)
+-- `e` is kind `# Type`
+```
+
+If a typeclass's parameter's Kind is `Type`, an instance cannot be made for a type of kind `# Type` or `Type -> Type`.
+
 ## Rows
 
-Rows can't appear in instances as the head.
+Concrete Row literals cannot appear in instances.
 
 ``` purescript
 class M t
--- XXX Can't write an instance for a specific row.
+-- Can't write an instance for a specific row.
 instance mClosedRow :: M ()
+class M' (t :: # Type)
+-- Can write an instance for a generic row.
+instance mAnyRow :: M r
 ```
 
-Instance selection works by looking at the "head" types of each type class parameter. Functional dependencies also plays a role, but we'll not consider that for now to simplify the explanation. The "head" of a type is the top-most type constructor, for example the head of `Array Int` is `Array` and the head of `Record r` is `Record`. Row is of kind `# Type`, and this kind is simply restricted from being the head in an instance.
+Instance selection works by looking at the "head" types of each type class parameter. Functional dependencies also plays a role, but we'll not consider that for now to simplify the explanation. The "head" of a type is the top-most type constructor, for example the head of `Array Int` is `Array` and the head of `Record r` is `Record`.
 
 As rows and records can easily be conflated to refer to the same thing, their difference is important to note here. `Record` is a simple type constructor in PureScript and therefore can be a head in an instance.
 
 ``` purescript
 class M t
--- OOO Can write an instance for a `Record` without specifying the row inside.
+-- Can write an instance for a `Record` without specifying a concrete row inside.
 instance mRec :: M (Record r)
--- XXX Can't specify a Record having an empty row, specifically.
+-- Can't specify a Record having an empty row, specifically.
 instance mRec' :: M (Record ())
--- XXX Further, can't specify a Record having a one-label row, specifically.
+-- Further, can't specify a Record having a one-label row, specifically.
 instance mRec'' :: M (Record (a :: Int))
 ```
 

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -82,7 +82,7 @@ For multi-parameter type classes, the orphan instance check requires that the in
 
 ## Kinds
 
-A typeclass's type parameter can specify the kind of types it applies to. If it doesn't specify the type's kind, it can be inferred by the typeclass's methods.
+Type class parameters do not need to be of kind Type. To explicitly specify a different kind, the parameter can be annotated with a kind signature. Unless the kind of a type parameter is explicitly annotated, it will be implicitly inferred based on how the type parameter is used in the type class's method signatures.
 
 ``` purescript
 class A a
@@ -130,7 +130,7 @@ instance mAnyRow :: M r
 
 Instance selection works by looking at the "head" types of each type class parameter. Functional dependencies also plays a role, but we'll not consider that for now to simplify the explanation. The "head" of a type is the top-most type constructor, for example the head of `Array Int` is `Array` and the head of `Record r` is `Record`.
 
-As rows and records can easily be conflated to refer to the same thing, their difference is important to note here. `Record` is a simple type constructor in PureScript and therefore can be a head in an instance.
+As rows and records can easily be conflated to refer to the same thing, their difference is important to note here. `Record` is a type constructor in PureScript and therefore can be a head in an instance.
 
 ``` purescript
 class M t

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -80,6 +80,26 @@ In fact, a type similar to this `AddInt` is provided in `Data.Monoid.Additive`, 
 
 For multi-parameter type classes, the orphan instance check requires that the instance is either in the same module as the class, or the same module as at least one of the types occurring in the instance. (TODO: example)
 
+## Rows
+
+Rows can't appear in instances as the head. Following is an explanation for this.
+
+Instance selection works by looking at the "head" types of each type class parameter. Functional dependencies also plays a role, but we'll not consider that for now to simplify the explanation. The "head" of a type is the top-most type constructor, for example the head of `Array Int` is `Array` and the head of `Record r` is `Record`. Row is of kind `# Type`, and this kind is simply restricted from being the head in an instance.
+
+As rows and records can easily be conflated to refer to the same thing, their difference is important to note here. `Record` is a simple type constructor in PureScript and therefore can be a head in an instance. Rows, however, can not. See this example:
+
+```
+class M t
+-- OOO We can write an instance for a generic `Record`.
+instance mRec :: M (Record r)
+-- But we *can't* write one for a "specific" Record row.
+-- XXX Can't specify an empty row.
+instance mRec' :: M (Record ())
+-- XXX Can't specify a row having a label.
+instance mRec'' :: M (Record (a :: Int))
+```
+
+A reason for this is that PureScript doesn't allow orphan instances. Row has an unbounded/open set of labels and combination of labels and types. Each unique row has a unique type. A unique row value's type doesn't have a name in a module, so to avoid orphan instances, its instance of a class would need to be defined in the same module as the typeclass. Typeclasses like Ord and Semigroup can't have an instance for every specific row that people want to use - it's untenable.
 
 ## Functional Dependencies
 

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -82,24 +82,29 @@ For multi-parameter type classes, the orphan instance check requires that the in
 
 ## Rows
 
-Rows can't appear in instances as the head. Following is an explanation for this.
+Rows can't appear in instances as the head.
+
+``` purescript
+class M t
+-- XXX Can't write an instance for a specific row.
+instance mClosedRow :: M ()
+```
 
 Instance selection works by looking at the "head" types of each type class parameter. Functional dependencies also plays a role, but we'll not consider that for now to simplify the explanation. The "head" of a type is the top-most type constructor, for example the head of `Array Int` is `Array` and the head of `Record r` is `Record`. Row is of kind `# Type`, and this kind is simply restricted from being the head in an instance.
 
-As rows and records can easily be conflated to refer to the same thing, their difference is important to note here. `Record` is a simple type constructor in PureScript and therefore can be a head in an instance. Rows, however, can not. See this example:
+As rows and records can easily be conflated to refer to the same thing, their difference is important to note here. `Record` is a simple type constructor in PureScript and therefore can be a head in an instance.
 
-```
+``` purescript
 class M t
--- OOO We can write an instance for a generic `Record`.
+-- OOO Can write an instance for a `Record` without specifying the row inside.
 instance mRec :: M (Record r)
--- But we *can't* write one for a "specific" Record row.
--- XXX Can't specify an empty row.
+-- XXX Can't specify a Record having an empty row, specifically.
 instance mRec' :: M (Record ())
--- XXX Can't specify a row having a label.
+-- XXX Further, can't specify a Record having a one-label row, specifically.
 instance mRec'' :: M (Record (a :: Int))
 ```
 
-A reason for this is that PureScript doesn't allow orphan instances. Row has an unbounded/open set of labels and combination of labels and types. Each unique row has a unique type. A unique row value's type doesn't have a name in a module, so to avoid orphan instances, its instance of a class would need to be defined in the same module as the typeclass. Typeclasses like Ord and Semigroup can't have an instance for every specific row that people want to use - it's untenable.
+A reason for rows being disallowed from appearing in instances is that PureScript doesn't allow orphan instances. Row has an unbounded/open set of labels and combination of labels and types. Each unique row has a unique type. A unique row value's type doesn't have a name in a module, so to avoid orphan instances, its instance of a class would need to be defined in the same module as the typeclass.
 
 ## Functional Dependencies
 


### PR DESCRIPTION
The other day I received an explanation of records and rows in typeclass instances. I'd like to have this clearly explained in one place, so here's my attempt at that. It needs fact-checking.

Also, this doesn't incorporate `RowList` representation of a Row, which can be used to overcome this limitation of rows in instances. I don't know how that relates to this explanation.