### PR TITLE
Replace psci with repl in command line

### DIFF
--- a/errors/CycleInDeclaration.md
+++ b/errors/CycleInDeclaration.md
@@ -3,7 +3,7 @@
 ## Example
 
 ```text
-$ pulp psci
+$ pulp repl
 
 > x = x
 Error found:

--- a/guides/Eff.md
+++ b/guides/Eff.md
@@ -49,7 +49,7 @@ This example requires the [`purescript-console`](https://pursuit.purescript.org/
 
 If you save this file as `src/RandomExample.purs`, you will be able to compile and run it using PSCi:
 
-    pulp psci
+    pulp repl
 
     > import RandomExample
     > printRandom

--- a/guides/Getting-Started.md
+++ b/guides/Getting-Started.md
@@ -165,7 +165,7 @@ answer = sum multiples
 
 It is possible to load this file directly into the REPL and to continue working:
 
-    pulp psci
+    pulp repl
     > import Euler
     > answer
     233168

--- a/guides/PSCi.md
+++ b/guides/PSCi.md
@@ -11,7 +11,7 @@ $ cd my-project # Enter an empty folder
 
 $ pulp init # Initialize a pulp environment
 
-$ pulp psci # Fire up the interpreter psci
+$ pulp repl # Fire up the interpreter psci
 
 PSCi, version 0.9.1
 Type :? for help

--- a/guides/QuickCheck.md
+++ b/guides/QuickCheck.md
@@ -21,7 +21,7 @@ Create a new project using Pulp, install `purescript-quickcheck`, and open PSCi:
 ```text
 pulp init
 bower install purescript-quickcheck
-pulp psci
+pulp repl
 ```
 
 Start by importing the QuickCheck library:


### PR DESCRIPTION
Actually, I don't know if there is any difference between `pulp psci` and `pulp repl`, but there is only `pulp repl` listed under `pulp --help` in pulp 11. So to avoid confusion, I believe it better to remove `pulp psci` in the doc.