### PR TITLE
included atom plugin under Editor & tools section

### DIFF
--- a/ecosystem/Editor-and-tool-support.md
+++ b/ecosystem/Editor-and-tool-support.md
@@ -5,6 +5,7 @@
 
 - [purescript-contrib/atom-language-purescript](https://github.com/purescript-contrib/atom-language-purescript) provides syntax highlighting
 - [nwolverson/atom-ide-purescript](https://github.com/nwolverson/atom-ide-purescript) provides build support,   REPL, and autocomplete etc. via [psc-ide](https://github.com/purescript/purescript/tree/master/psc-ide-server)
+- [nikhilnagaraju/search-pursuit](https://github.com/nikhilnagaraju/search-pursuit) search any modules, functions on pursuit from editor.
 
 #### Emacs
  Either use these two:


### PR DESCRIPTION
Made a simple Atom plugin which helps to quickly refer Purescript modules , functions or documentation on Pursuit