### PR TITLE
update FFI guide foreign data import syntax

### DIFF
--- a/guides/FFI.md
+++ b/guides/FFI.md
@@ -214,10 +214,10 @@ The `Data.Foreign` module (available in the `purescript-foreign` package) define
 
 It is often useful when wrapping Javascript APIs to create new types at a specific kind for use with the FFI.
 
-For example, suppose we have a Javascript library `frob` which defines the `Frob` data structure and associated functions. To give meaningful types to those functions, it might be useful to define a type `Frob` at kind `*`. We can do this as follows:
+For example, suppose we have a Javascript library `frob` which defines the `Frob` data structure and associated functions. To give meaningful types to those functions, it might be useful to define a type `Frob` at kind `Type`. We can do this as follows:
 
 ``` haskell
-foreign import data Frob :: *
+foreign import data Frob :: Type
 ```
 
 The type `Frob` can now be used in other types, or in foreign import declarations:


### PR DESCRIPTION
`*` was changed to `Type` in 0.11.0