### PR TITLE
suggest using generics for CannotDerive error

### DIFF
--- a/errors/CannotDerive.md
+++ b/errors/CannotDerive.md
@@ -5,7 +5,7 @@
 ```purescript
 data Bool = True | False
 
-derive instance heytingAlgebraBool :: HeytingAlgebra Bool
+derive instance showBool :: Show Bool
 ```
 
 ## Cause
@@ -16,3 +16,10 @@ support does not exist.
 ## Fix
 
 - You will need to write an instance yourself.
+- If you want to derive e.g. `Show` you can use [Generics](https://github.com/purescript/documentation/blob/master/guides/Generic.md#show-eq-ord) like this:
+  - install `purescript-generics-rep`
+  - ```purescript
+       derive instance genericBool :: Generic Bool _
+       
+       instance showBool :: Show Bool where show = genericShow
+     ```

--- a/errors/CannotDerive.md
+++ b/errors/CannotDerive.md
@@ -16,10 +16,4 @@ support does not exist.
 ## Fix
 
 - You will need to write an instance yourself.
-- If you want to derive e.g. `Show` you can use [Generics](https://github.com/purescript/documentation/blob/master/guides/Generic.md#show-eq-ord) like this:
-  - install `purescript-generics-rep`
-  - ```purescript
-       derive instance genericBool :: Generic Bool _
-       
-       instance showBool :: Show Bool where show = genericShow
-     ```
+- If you want to derive e.g. `Show` you can use [Generics](https://github.com/purescript/documentation/blob/master/guides/Generic.md#show-eq-ord).


### PR DESCRIPTION
I changed `HeytingAlgebra Bool` to `Show Bool`, becase I think that a more approachable example.