### PR TITLE
Update compiler solvable type classes, Fixes #157

### DIFF
--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -114,12 +114,22 @@ foo x = x
 
 Currently, the following type classes can be automatically solved:
 
+Symbol-related class
+
 - [`IsSymbol`](https://pursuit.purescript.org/packages/purescript-symbols/3.0.0/docs/Data.Symbol#t:IsSymbol)
+- `ConsSymbol`
 - [`AppendSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:AppendSymbol)
-- [`Equals`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:Equals)
 - [`CompareSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:CompareSymbol)
+
+Rows-related classes
+
+- [`RowToList`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Row#t:RowToList)
 - [`RowCons`](https://pursuit.purescript.org/builtins/docs/Prim#t:RowCons), computes the union of two rows of types
+- [`Cons`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Row#t:Cons)
 - [`Union`](https://pursuit.purescript.org/builtins/docs/Prim#t:Union), computes the union of two rows of types
+
+Other classes
+
 - [`Partial`](https://pursuit.purescript.org/builtins/docs/Prim#t:Partial)
 - [`Fail`](https://pursuit.purescript.org/builtins/docs/Prim#t:Fail)
 - [`Warn`](https://pursuit.purescript.org/builtins/docs/Prim#t:Warn)

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -117,16 +117,15 @@ Currently, the following type classes can be automatically solved:
 Symbol-related class
 
 - [`IsSymbol`](https://pursuit.purescript.org/packages/purescript-symbols/3.0.0/docs/Data.Symbol#t:IsSymbol)
-- `ConsSymbol`
 - [`AppendSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:AppendSymbol)
 - [`CompareSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:CompareSymbol)
 
 Rows-related classes
 
 - [`RowToList`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Row#t:RowToList)
-- [`RowCons`](https://pursuit.purescript.org/builtins/docs/Prim#t:RowCons), computes the union of two rows of types
+- [`RowCons`](https://pursuit.purescript.org/builtins/docs/Prim#t:RowCons)
 - [`Cons`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Row#t:Cons)
-- [`Union`](https://pursuit.purescript.org/builtins/docs/Prim#t:Union), computes the union of two rows of types
+- [`Union`](https://pursuit.purescript.org/builtins/docs/Prim#t:Union)
 
 Other classes
 

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -114,7 +114,7 @@ foo x = x
 
 Currently, the following type classes can be automatically solved:
 
-Symbol-related class
+Symbol-related classes
 
 - [`IsSymbol`](https://pursuit.purescript.org/packages/purescript-symbols/3.0.0/docs/Data.Symbol#t:IsSymbol)
 - [`AppendSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:AppendSymbol)

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -114,8 +114,12 @@ foo x = x
 
 Currently, the following type classes can be automatically solved:
 
-- `Warn`
-- [`IsSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/1.0.0/docs/Type.Data.Symbol#t:IsSymbol)
-- [`CompareSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/1.0.0/docs/Type.Data.Symbol#t:CompareSymbol)
-- [`AppendSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/1.0.0/docs/Type.Data.Symbol#t:AppendSymbol)
-- `Union`, which computes the union of two rows of types
+- [`IsSymbol`](https://pursuit.purescript.org/packages/purescript-symbols/3.0.0/docs/Data.Symbol#t:IsSymbol)
+- [`AppendSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:AppendSymbol)
+- [`Equals`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:Equals)
+- [`CompareSymbol`](https://pursuit.purescript.org/packages/purescript-typelevel-prelude/2.5.0/docs/Type.Data.Symbol#t:CompareSymbol)
+- [`RowCons`](https://pursuit.purescript.org/builtins/docs/Prim#t:RowCons), computes the union of two rows of types
+- [`Union`](https://pursuit.purescript.org/builtins/docs/Prim#t:Union), computes the union of two rows of types
+- [`Partial`](https://pursuit.purescript.org/builtins/docs/Prim#t:Partial)
+- [`Fail`](https://pursuit.purescript.org/builtins/docs/Prim#t:Fail)
+- [`Warn`](https://pursuit.purescript.org/builtins/docs/Prim#t:Warn)


### PR DESCRIPTION
https://github.com/purescript/purescript/blob/38f631c71367cffcc973ce0dab2229e81969e161/src/Language/PureScript/TypeChecker/Entailment.hs#L61

There are other classes which are related to these but aren't solved, BTW, like `Equals` and `ListToRow`, but I don't think those belong here.`