### PR TITLE
Add @mattaudesse to CONTRIBUTORS.md w/ CC BY-NC-SA 3.0 license

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,6 +34,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@Xandaros](https://github.com/Xandaros) | @Xandaros | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@kika](https://github.com/kika) | Kirill Pertsev | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@chexxor](https://github.com/chexxor) | Alex Berg | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@mattaudesse](https://github.com/mattaudesse) | Matt Audesse | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 


### PR DESCRIPTION
(Pertains to #151)

My [previous commits](https://github.com/purescript/documentation/commits?author=mattaudesse) are tiny but I'll throw my name on the heap in case that helps ease licensing issues.

I would've just responded to the thread like @hdgarrood asked in #151 except his PR was already merged.