### PR TITLE
Add dep management directory. Ref it from PS w/o Node.

### DIFF
--- a/guides/Bundling-for-Web-Browser.md
+++ b/guides/Bundling-for-Web-Browser.md
@@ -1,10 +1,33 @@
 # Bundling for a Web Browser
 
-Currently, the PureScript compiler outputs CommonJS-formatted JavaScript modules, which is just one of several JavaScript module formats. Other JavaScript module formats include AMD, UMD, ES6, IIFE, SystemJS, and Global. The CommonJS module format was invented by the early NodeJS app ecosystem, as it has a different set of limitations than the web browser app ecosystem. The primary difference that relates to JavaScript module formats is that of loading dependent modules. NodeJS is a customized JavaScript runtime, and one of the features they added to the JavaScript language is support for synchronous module loading. NodeJS can do this while a web browser can not because NodeJS loads dependent modules using simple filesystem access, a relatively low performance cost, whereas a web browser needs to send an HTTP request to the website's server to request subsequent modules, a quite large performance cost.
+A language's libraries are often maintained as modules separate from any specific application to enable them to be easily re-used across applications. Any JavaScript app which uses shared libraries will be loading specific modules and specific functions in those modules. In JavaScript, each file is treated as a separate module.
+
+In a web browser, loading a dependency is a network request. Remembering that dependencies have dependencies, you can look at any simple JavaScript application and see that it consists of dozens or hundreds of modules. When you run such a JavaScript application in a browser, then, you'll see dozens or hundreds of network requests as it fetches its dependencies.
+
+A bundler will reduce an application's dependency graph by moving a module's dependencies and transitive dependencies into the module itself. This means a web browser does not need to load a JavaScript app's dependencies. If an application wants to make its bundle smaller, some bundlers can split the app into chunks and lazy-load them when they are needed.
+
+## Module Formats
+
+Bundlers can export the bundle in one of several JavaScript module formats. It's also important to know that some bundlers only support importing an application using a specific module format, though you can apply a plugin to add support for other module formats.
+
+Currently, the PureScript compiler outputs CommonJS-formatted JavaScript modules. Other JavaScript module formats include AMD, UMD, ES6, IIFE, and SystemJS. Following is a quick overview of the various module formats.
+
+The CommonJS format offers synchronous module loading and is the de facto module format of modules used by the NodeJS ecosystem.
+
+The AMD format was invented to support loading modules in a web browser asynchronously across the network.=
+
+The UMD format unifies the CommonJS and AMD formats to enable modules in its format to be loaded as a CommonJS module or as an AMD module, at the cost of a slightly more incomprehensible module format.
+
+The IIFE format isn't a complete module system, as it doesn't define a way of loading dependencies, but it is still useful as a format to use for a top-level module, the one first loaded and executed by a web browser, as it uses a JavaScript closure to ensure only specifically exported values are exported and arranges them onto a single object, rather than independently defining each export on the global scope.
+
+The ES6 format is the new JavaScript standard module format, but it is not currently not supported by most web browsers. You can use this format during development but will need to transpile to a different format when deploying to production.
+
+SystemJS is a module format which closely follows the ECMAScript specifications, but because dynamic loading isn't included in the ES6 specification yet SystemJS offers some guidance as a reference implementation, and can perhaps be called a polyfill, until it's added to the ECMAScript specification and all major browsers implement it.
+
 
 ## Bundling
 
-To run a JavaScript app which uses CommonJS-formatted modules in a web browser, then, requires compiling it to a module format supported by a web browser. In simple browser apps, the resulting output will likely be just a single, very big JavaScript file with modules removed or wrapped in a similar implementation of CommonJS modules.
+To run a JavaScript app which uses CommonJS-formatted modules in a web browser requires compiling it to a module format supported by a web browser. In simple browser apps, the resulting output will likely be just a single, very big JavaScript file with modules removed or wrapped in a similar implementation of CommonJS modules.
 
 The programs which perform this compilation process are generally called "bundlers". The first program which did this was [Browserify](http://browserify.org/) but many alternative bundlers have been created since then. Currently the most popular and well-supported bundler is [Webpack](https://webpack.js.org/), but other fine options include [RollupJS](https://rollupjs.org/) and [ParcelJS](https://parceljs.org/). Generally, a bundler works by specifying an entrypoint JavaScript file, a desired output module format, and other functions to perform while the bundler traverses and bundles modules, called plugins.
 
@@ -24,111 +47,14 @@ main();
 // Main.main();
 ```
 
+### Tools
 
-### Webpack
-
-Install Webpack using their [installation guide](https://webpack.js.org/guides/installation/) or a different method of your choice. You might also need to install a "webpack-cli" package.
-
-Webpack supports configuration by command-line arguments and by configuration file, but because many configuration options can't be defined by command-line arguments, it's recommended to use a configuration file. Create a webpack configuration file by entering the following into a "webpack.config.js" file in the root of your project directory.
-
-``` JavaScript
-// webpack.config.js
-
-module.exports = {
-  // Enter here. If the name of your PureScript entry module is named "Main",
-  //   by default it will be output to the "./output/Main/index.js" file.
-  entry: './output/Main/index.js',
-  // Output the bundled program to "bundle.js" file in the current directory.
-  output: {
-    filename: 'bundle.js',
-    path: __dirname
-  }
-};
-```
-
-Then execute Webpack.
-
-``` sh
-# If you installed from NPM
-$ ./node_modules/.bin/webpack
-```
-
-Webpack should output something like the following. You can see it produced one asset, called bundle.js, which it called "Chunk number 0", and you can see each module which was included in that bundle.
-
-``` sh
-Hash: 8891a2a784e39f88c7ed
-Version: webpack 4.0.0
-Time: 1690ms
-Built at: 2/24/2018 9:12:40 PM
-    Asset      Size  Chunks             Chunk Names
-bundle.js  24.6 KiB       0  [emitted]  main
-Entrypoint main = bundle.js
-   [2] ./output/Data.Ring/index.js 1.27 KiB {0} [built]
-   [4] ./output/Data.Function/index.js 803 bytes {0} [built]
-   [6] ./output/Data.Eq/index.js 1.59 KiB {0} [built]
-   [7] ./output/Data.Show/index.js 964 bytes {0} [built]
-   [8] ./output/Control.Apply/index.js 2.89 KiB {0} [built]
-   [9] ./output/Data.Semigroup/index.js 1.07 KiB {0} [built]
-  [10] ./output/Data.EuclideanRing/index.js 3.25 KiB {0} [built]
-  [11] ./output/Data.Void/index.js 559 bytes {0} [built]
-  [12] ./output/Control.Category/index.js 483 bytes {0} [built]
-  [13] ./output/Control.Applicative/index.js 1.88 KiB {0} [built]
-  [14] ./output/Data.Ord/index.js 7.89 KiB {0} [built]
-  [20] ./output/Prelude/index.js 1.36 KiB {0} [built]
-  [24] ./output/Control.Monad.Eff/index.js 1.7 KiB {0} [built]
-  [26] ./output/Control.Monad.Eff.Console/index.js 971 bytes {0} [built]
-  [47] ./output/Main/index.js 313 bytes {0} [built]
-    + 33 hidden modules
-```
-
-
-### RollupJS
-
-Install RollupJS using their [quick start guide](https://rollupjs.org/guide/en#quick-start) or a different method of your choice.
-
-Rollup supports configuration by command-line arguments and by configuration file, but because some configuration options can't be defined by command-line arguments, such as plugins, it's recommended to use a configuration file. Create a RollupJS configuration file by entering the following into a "rollup.config.js" file in the root of your project directory.
-
-``` JavaScript
-// rollup.config.js
-
-// RollupJS supports only ES6 modules.
-// PureScript outputs CommonJS modules and refers to other PS modules using Node-style
-//   module refereneces, so we need to add support for this to Rollup using two plugins.
-import commonjs from 'rollup-plugin-commonjs';
-import nodeResolve from 'rollup-plugin-node-resolve';
-
-export default {
-  input: 'output/Main/index.js',
-  output: {
-    file: 'myapp-bundle.js',
-    // If you want to make an in-browser executable, you'll need an input like "main-runner.js" and use an output format of "iife".
-    format: 'cjs',
-    exports: 'named'
-  },
-  plugins: [
-    nodeResolve(),
-    commonjs()
-  ]
-};
-```
-
-Then execute RollupJS.
-
-``` sh
-# If you installed from NPM
-$ ./node_modules/.bin/rollup -c
-```
-
-RollupJS should output something like the following. You can see it bundled "output/Main/index.js" and its dependencies into the "myapp-bundle.js" file.
-
-``` sh
-$ ./node_modules/.bin/rollup -c
-
-output/Main/index.js → myapp-bundle.js...
-created myapp-bundle.js in 874ms
-```
+- [webpack quick-start](guides/Bundling/Webpack.md)
+- [Rollup quick-start](guides/Bundling/Rollup.md)
 
 
 ## Note on ES6 modules
 
-ECMAScript 6, the latest version of the JavaScript language, enables an ES6 JavaScript module to define its dependencies in a synchronous manner while keeping its ability to be executed in an ES6-compliant web browser. PureScript currently doesn't output ES6-formatted modules because not all browsers completely support ES6 and the PureScript project wants to output JavaScript compatible with as many JavaScript runtimes as possible. ES6 modules are enticing because they remove the need to perform a bundling step.
+ECMAScript 6, the latest version of the JavaScript language, adds a module system which is similar to CommonJS but is slightly restricted to enable it to be statically analyzed. Static analysis enables an ES6 JavaScript module's dependencies to be asynchronously loaded prior to running the module, which enables the ES6 module to use its dependencies in a synchronous manner. PureScript currently doesn't output ES6-formatted modules, partly because not all browsers completely support ES6 and partly because its FFI parser doesn't support parsing ES6. ES6 modules are enticing because they remove the need to perform a bundling step.
+
+A relevant topic here is loading a dynamically-chosen dependency, a commonly-used feature of the CommonJS module system. This facility is not included in the ES6 specification, but work is underway to add it to a future version of the specification. The suggested syntax for this is `import('./dist/some-module.js').then(({ default: main }) => main());`, compared to CommonJS's `const { default: main } = require('./dist/some-module.js'); main();`. In ES6, the asynchronous nature of this operation surfaces, as we see the operation returns a Promise containing the requested functions from the module's exports.

--- a/guides/Bundling-for-Web-Browser.md
+++ b/guides/Bundling-for-Web-Browser.md
@@ -1,0 +1,77 @@
+# Bundling for a Web Browser
+
+Currently, the PureScript compiler outputs CommonJS-formatted JavaScript modules, which is just one of several JavaScript module formats. Other JavaScript module formats include AMD, UMD, ES6, IIFE, SystemJS, and Global. The CommonJS module format was invented by the early NodeJS app ecosystem, as it has a different set of limitations than the web browser app ecosystem. The primary difference that relates to JavaScript module formats is that of loading dependent modules. NodeJS is a customized JavaScript runtime, and one of the features they added to the JavaScript language is support for synchronous module loading. NodeJS can do this while a web browser can not because NodeJS loads dependent modules using simple filesystem access, a relatively low performance cost, whereas a web browser needs to send an HTTP request to the website's server to request subsequent modules, a quite large performance cost.
+
+## Bundling
+
+To run a JavaScript app which uses CommonJS-formatted modules in a web browser, then, requires compiling it to a module format supported by a web browser. In simple browser apps, the resulting output will likely be just a single, very big JavaScript file with modules removed or wrapped in a similar implementation of CommonJS modules.
+
+The programs which perform this compilation process are generally called "bundlers". The first program which did this was [Browserify](http://browserify.org/). Currently the most popular and well-supported bundler is [Webpack](https://webpack.js.org/), but other fine options include [RollupJS](https://rollupjs.org/) and [ParcelJS](https://parceljs.org/). Generally, a bundler works by specifying an entrypoint JavaScript file, a desired output module format, and other functions to perform while bundling, called plugins.
+
+See the documentation provided by those tools for full information of how to use them. As an introduction, we'll see a basic example of these tools.
+
+### Webpack
+
+Install Webpack using their [installation guide](https://webpack.js.org/guides/installation/) or a different method of your choice. You might also need to install a "webpack-cli" package.
+
+Create a webpack configuration file by entering the following configuration in a "webpack.config.js" file in the root of your project directory.
+
+``` JavaScript
+module.exports = {
+  // Enter here. If the name of your PureScript entry module is named "Main",
+  //   by default it will be output to the "./output/Main/index.js" file.
+  entry: './output/Main/index.js',
+  // Output the bundled program to "bundle.js" file in the current directory.
+  output: {
+    path: __dirname,
+    pathinfo: true,
+    filename: 'bundle.js'
+  }
+};
+```
+
+Then execute Webpack.
+
+``` sh
+# If you installed from NPM
+$ ./node_modules/.bin/webpack
+# OR if you installed a different way, execute it your way.
+$ PATH=~/path/to/webpack-dir webpack
+```
+
+Webpack should output something like the following lines. You can see it produced one asset, called bundle.js, which it called "Chunk number 0", and you can see each module which was included in that bundle.
+
+``` sh
+Hash: 8891a2a784e39f88c7ed
+Version: webpack 4.0.0
+Time: 1690ms
+Built at: 2/24/2018 9:12:40 PM
+    Asset      Size  Chunks             Chunk Names
+bundle.js  24.6 KiB       0  [emitted]  main
+Entrypoint main = bundle.js
+   [2] ./output/Data.Ring/index.js 1.27 KiB {0} [built]
+   [4] ./output/Data.Function/index.js 803 bytes {0} [built]
+   [6] ./output/Data.Eq/index.js 1.59 KiB {0} [built]
+   [7] ./output/Data.Show/index.js 964 bytes {0} [built]
+   [8] ./output/Control.Apply/index.js 2.89 KiB {0} [built]
+   [9] ./output/Data.Semigroup/index.js 1.07 KiB {0} [built]
+  [10] ./output/Data.EuclideanRing/index.js 3.25 KiB {0} [built]
+  [11] ./output/Data.Void/index.js 559 bytes {0} [built]
+  [12] ./output/Control.Category/index.js 483 bytes {0} [built]
+  [13] ./output/Control.Applicative/index.js 1.88 KiB {0} [built]
+  [14] ./output/Data.Ord/index.js 7.89 KiB {0} [built]
+  [20] ./output/Prelude/index.js 1.36 KiB {0} [built]
+  [24] ./output/Control.Monad.Eff/index.js 1.7 KiB {0} [built]
+  [26] ./output/Control.Monad.Eff.Console/index.js 971 bytes {0} [built]
+  [47] ./output/Main/index.js 313 bytes {0} [built]
+    + 33 hidden modules
+```
+
+
+### RollupJS
+
+!!! To do
+
+## Note on ES6 modules
+
+ECMAScript 6, the latest version of the JavaScript language, enables an ES6 JavaScript module to define its dependencies in a synchronous manner while keeping its ability to be executed in an ES6-compliant web browser. PureScript currently doesn't output ES6-formatted modules because not all browsers completely support ES6 and PureScript wants to output JavaScript which is compatible with all JavaScript runtimes. ES6 modules are enticing because they remove the need to perform a bundling step.

--- a/guides/Bundling/Rollup.md
+++ b/guides/Bundling/Rollup.md
@@ -1,0 +1,54 @@
+# Rollup
+
+> Rollup is a module bundler for JavaScript which compiles small pieces of code into something larger and more complex, such as a library or application. It uses the new standardized format for code modules included in the ES6 revision of JavaScript, instead of previous idiosyncratic solutions such as CommonJS and AMD. ES6 modules let you freely and seamlessly combine the most useful individual functions from your favorite libraries. This will eventually be possible natively, but Rollup lets you do it today.
+> - https://rollupjs.org/guide/en
+
+For more information about Rollup, read their documentation:
+
+- [Rollup documentation](https://rollupjs.org/guide/en#introduction)
+
+## Usage Introduction
+
+Install RollupJS using their [quick start guide](https://rollupjs.org/guide/en#quick-start) or a different method of your choice.
+
+Rollup supports configuration by command-line arguments and by configuration file, but because some configuration options can't be defined by command-line arguments, such as plugins, it's recommended to use a configuration file. Create a RollupJS configuration file by entering the following into a "rollup.config.js" file in the root of your project directory.
+
+``` JavaScript
+// rollup.config.js
+
+// RollupJS supports only ES6 modules.
+// PureScript outputs CommonJS modules and refers to other PS modules using Node-style
+//   module refereneces, so we need to add support for this to Rollup using two plugins.
+import commonjs from 'rollup-plugin-commonjs';
+import nodeResolve from 'rollup-plugin-node-resolve';
+
+export default {
+  input: 'output/Main/index.js',
+  output: {
+    file: 'myapp-bundle.js',
+    // If you want to make an in-browser executable, you'll need an input like "main-runner.js" and use an output format of "iife".
+    format: 'cjs',
+    exports: 'named'
+  },
+  plugins: [
+    nodeResolve(),
+    commonjs()
+  ]
+};
+```
+
+Then execute RollupJS.
+
+``` sh
+# If you installed from NPM
+$ ./node_modules/.bin/rollup -c
+```
+
+RollupJS should output something like the following. You can see it bundled "output/Main/index.js" and its dependencies into the "myapp-bundle.js" file.
+
+``` sh
+$ ./node_modules/.bin/rollup -c
+
+output/Main/index.js → myapp-bundle.js...
+created myapp-bundle.js in 874ms
+```

--- a/guides/Bundling/Webpack.md
+++ b/guides/Bundling/Webpack.md
@@ -1,0 +1,71 @@
+# Webpack
+
+> At its core, webpack is a static module bundler for modern JavaScript applications. When webpack processes your application, it recursively builds a dependency graph that includes every module your application needs, then packages all of those modules into one or more bundles.
+> - https://webpack.js.org/concepts/
+
+For more information about webpack, read their documentation:
+
+- [webpack concepts](https://webpack.js.org/concepts/)
+- [webpack configuration](https://webpack.js.org/configuration/)
+- [webpack API](https://webpack.js.org/api/)
+- [webpack guides](https://webpack.js.org/guides/)
+- [webpack loaders](https://webpack.js.org/loaders/)
+- [webpack plugins](https://webpack.js.org/plugins/)
+
+Following is a quick-start guide to using webpack.
+
+## Usage Introduction
+
+Install webpack using their [installation guide](https://webpack.js.org/guides/installation/) or a different method of your choice. You might also need to install a "webpack-cli" package.
+
+Webpack supports configuration by command-line arguments and by configuration file, but because many configuration options can't be defined by command-line arguments, it's recommended to use a configuration file. Create a webpack configuration file by entering the following into a "webpack.config.js" file in the root of your project directory.
+
+``` JavaScript
+// webpack.config.js
+
+module.exports = {
+  // Enter here. If the name of your PureScript entry module is named "Main",
+  //   by default it will be output to the "./output/Main/index.js" file.
+  entry: './output/Main/index.js',
+  // Output the bundled program to "bundle.js" file in the current directory.
+  output: {
+    filename: 'bundle.js',
+    path: __dirname
+  }
+};
+```
+
+Then execute webpack.
+
+``` sh
+# If you installed from NPM
+$ ./node_modules/.bin/webpack
+```
+
+Webpack should output something like the following. You can see it produced one asset, called bundle.js, which it called "Chunk number 0", and you can see each module which was included in that bundle.
+
+``` sh
+Hash: 8891a2a784e39f88c7ed
+Version: webpack 4.0.0
+Time: 1690ms
+Built at: 2/24/2018 9:12:40 PM
+    Asset      Size  Chunks             Chunk Names
+bundle.js  24.6 KiB       0  [emitted]  main
+Entrypoint main = bundle.js
+   [2] ./output/Data.Ring/index.js 1.27 KiB {0} [built]
+   [4] ./output/Data.Function/index.js 803 bytes {0} [built]
+   [6] ./output/Data.Eq/index.js 1.59 KiB {0} [built]
+   [7] ./output/Data.Show/index.js 964 bytes {0} [built]
+   [8] ./output/Control.Apply/index.js 2.89 KiB {0} [built]
+   [9] ./output/Data.Semigroup/index.js 1.07 KiB {0} [built]
+  [10] ./output/Data.EuclideanRing/index.js 3.25 KiB {0} [built]
+  [11] ./output/Data.Void/index.js 559 bytes {0} [built]
+  [12] ./output/Control.Category/index.js 483 bytes {0} [built]
+  [13] ./output/Control.Applicative/index.js 1.88 KiB {0} [built]
+  [14] ./output/Data.Ord/index.js 7.89 KiB {0} [built]
+  [20] ./output/Prelude/index.js 1.36 KiB {0} [built]
+  [24] ./output/Control.Monad.Eff/index.js 1.7 KiB {0} [built]
+  [26] ./output/Control.Monad.Eff.Console/index.js 971 bytes {0} [built]
+  [47] ./output/Main/index.js 313 bytes {0} [built]
+    + 33 hidden modules
+```

--- a/guides/Dependency-Management.md
+++ b/guides/Dependency-Management.md
@@ -1,0 +1,38 @@
+# Purescript Dependency Management
+
+For a basic project, the first task for which a tool can be a great help is dependency resolution. Manually including open-source and community-maintained libraries from the PureScript ecosystem into your project can be rather time-consuming and error-prone, as these libraries are very small, can have their own transitive dependencies, and may only build with certain versions of their dependent libraries and PureScript compiler version. There are several tools which fill this need, and each of them approaches the problem with different presumptions and goals.
+
+Following is a list of these tools accompanied by an introduction. Feel free to make a pull request to add missing tools or update existing ones.
+
+
+## Git
+
+It's possible to use Git as a dependency management tool. You'll need to go find the PureScript library repos yourself, find the release tag you want, and clone them into a directory in your PureScript project. Then, pass the paths to these Purescript libraries to the compiler when building your project.
+
+More information: [guides/Dependency-Management/Git.md](guides/Dependency-Management/Git.md)
+
+
+## Bower
+
+Bower is a dependency manager whose differentiating features are its supports for soley a flat dependency tree and its ability to refer either to "registered" packages or to other package identifiers like Git URLs. A flat dependency tree is in contrast to NPM, which is unique in that it supports dependencies of arbitrary depth, which is a feature supported by NodeJS's own module system, CommonJS.
+
+Here, a flat dependency tree refers to where a dependency's dependencies are installed: in child directories within that dependency, or in sibling directories to that dependency. This distinction becomes relevant when considering how to handle two direct dependencies which depend on a common dependency. Should you have one copy of that common, transitive dependency installed, or two, one for each direct dependency. The latter is convenient when the direct dependencies require incompatible versions of the third dependency, while the former is convenient for reducing the size of the resulting build artifact, as it doesn't include duplicate libraries.
+
+
+## NPM
+
+NPM is a dependency manager whose differentiating features are its history with the NodeJS ecosystem and its support for a dependency tree of arbitrary depth, which is a feature of the NodeJS module system, CommonJS. It's important to note that NPM has recently added support for "deduping" an application's dependency tree, but only as a storage space optimization. PureScript requires a flat dependency tree, as the compiler will fail when it is given two modules having the same name, which means a single PureScript project can't have two versions of the same module. In addition to modules, a data type in a module must have only one implementation, i.e. `Foo` from `MyModule.Foo#v1.0.0` cannot coexist with `Foo` from `MyModule.Foo#v2.0.0`. This prevents a library giving you a `Foo` from v1 and passing it to a function which accepts a `Foo` from v2. For more information, see [Harry Garrood's "Why the PureScript community uses Bower"](http://harry.garrood.me/blog/purescript-why-bower/) blog post.
+
+
+## Yarn
+
+Yarn is an alternative implementation of the NPM package's dependency resolution algorithm, which aims to be faster and more user-friendly. In addition, it claims to support [declaring a flat package](https://yarnpkg.com/en/docs/package-json#flat-), but there are currently no reports of this satisfying the requirements of a PureScript dependency manager.
+
+
+## PSC-Package
+
+!!! to do
+
+## Purcell
+
+??? too soon?

--- a/guides/Dependency-Management/Git.purs
+++ b/guides/Dependency-Management/Git.purs
@@ -1,0 +1,31 @@
+# Using Git for PureScript Dependency Management
+
+It's possible to use Git as a dependency management tool. You'll need to go find the PureScript library repos yourself, find the release tag you want, and clone them into a directory in your PureScript project. Note that you'll need to also manually install the dependencies of your desired direct dependencies, which are called transitive dependencies. Then, pass the paths to these Purescript libraries to the compiler when building your project.
+
+For example:
+
+``` sh
+# In a PureScript project's directory
+$ mkdir ps-deps/
+$ git clone --branch v3.1.1 git@github.com:purescript/purescript-prelude.git ps-deps/purescript-prelude/
+$ git clone --branch v3.2.0 git@github.com:purescript/purescript-eff.git ps-deps/purescript-eff/
+$ git clone --branch v3.3.0 git@github.com:purescript/purescript-monoid.git ps-deps/purescript-monoid/
+$ git clone --branch v3.3.1 git@github.com:purescript/purescript-control.git ps-deps/purescript-control/
+$ git clone --branch v3.0.0 git@github.com:purescript/purescript-invariant.git ps-deps/purescript-invariant/
+$ git clone --branch v2.0.0 git@github.com:purescript/purescript-newtype.git ps-deps/purescript-newtype/
+$ git clone --branch v3.0.0 git@github.com:purescript/purescript-console.git ps-deps/purescript-console/
+# Include them when building
+$ purs compile 'src/**/*.purs' 'ps-deps/purescript-*/src/**/*.purs'
+```
+
+A PureScript module's FFI files are automatically discovered by the compiler, and therefore are not required as input to `purs compile`.
+
+If everything worked, you should see a series of lines indicating compilation status like:
+
+``` sh
+Compiling Control.Monad.Eff
+Compiling Control.Monad.Eff.Class
+Compiling Control.Monad.Eff.Console
+...
+```
+

--- a/guides/PureScript-Without-Node.md
+++ b/guides/PureScript-Without-Node.md
@@ -1,4 +1,5 @@
-The PureScript community has standardized on the NodeJS toolset to a certain extent: we use tools like Pulp, Browserify and Gulp, which run on NodeJS and are installed with NPM, and we use Bower for our package management. However, we have some users who would rather not, or cannot, run NodeJS on their machines. In this short post, I'll demonstrate how to use the PureScript compiler directly on the command line, and how to automate some processes using standard tooling.
+
+The PureScript community has standardized on tools like Pulp, Bower, Browserify, Webpack, and RollupJS, all of which use the NodeJS runtime and use NPM as their supported distribution channel. There are users who cannot, or prefer not to, use NodeJS-based tools. PureScript can be used without NodeJS-based tools.
 
 #### Creating a Project
 
@@ -22,58 +23,30 @@ main = log "Hello, World!"
 
 #### Installing Dependencies
 
-Instead of using Bower, we'll need to install dependencies manually. Let's fetch source packages using `git`. For this demo, I'll need `purescript-console`, which has dependencies on `purescript-eff` and `purescript-prelude`:
+We can use any dependency management strategy that doesn't rely on a NodeJS-based tool. Try using one of these techniques:
+
+- [Using Git for PureScript Dependency Management page](guides/Dependency-Management/Git.md)
+- [Using PSC-Package for PureScript Dependency Management page](guides/Dependency-Management/PSC-Package.md)
+
 
 ```text
 $ mkdir dependencies/
 $ git clone --branch v0.1.0 git@github.com:purescript/purescript-prelude.git dependencies/purescript-prelude/
 $ git clone --branch v0.1.0 git@github.com:purescript/purescript-eff.git dependencies/purescript-eff/
 $ git clone --branch v0.1.0 git@github.com:purescript/purescript-console.git dependencies/purescript-console/
+$ git clone --branch v3.3.0 git@github.com:purescript/purescript-invariant.git ps-deps/purescript-invariant/
 ```
 
 Note that, without Bower as our dependency manager, it's necessary to install all dependencies manually, including transitive dependencies. It's also necessary to manage versions by hand.
 
 #### Building Sources
 
-Now we can build our project. It is necessary to provide all source files explicitly to `psc`. The simplest way is to use a set of globs:
+It is necessary to provide all source files explicitly to the PureScript compiler. The simplest way is to use a set of file path globs.
 
 ```text
-$ psc src/Main.purs 'dependencies/purescript-*/src/**/*.purs'
+$ purs compile 'src/**/*.purs' 'ps-deps/purescript-*/src/**/*.purs'
 ```
 
-Note: FFI files are automatically discovered when a PureScript file uses `foreign import` and are not required in the globs.
+By default, `purs compile` will write a collection of CommonJS-formatted JavaScript modules to the `output` directory.
 
-If everything worked, you should see a collection of lines like this
-
-```text
-Compiling Control.Monad.Eff
-Compiling Control.Monad.Eff.Class
-Compiling Control.Monad.Eff.Console
-...
-```
-
-`psc` will write a collection of CommonJS modules to the output directory. You can use these CommonJS modules in NodeJS, but it is more likely that you will want to bundle them for use in the browser.
-
-#### Bundling JavaScript for the Browser
-
-To bundle the generated Javascript code, we will use the `psc-bundle` tool, which ships with the PureScript compiler binary distribution.
-
-`psc-bundle` takes a collection of CommonJS module files as input, and generates a single JavaScript file.
-
-Run `psc-bundle` with the following arguments:
-
-```text
-$ psc-bundle output/*/{index,foreign}.js --module Main --main Main
-```
-
-The `--module` argument specifies an _entry-point_ module, which will be used to determine dead code which can be removed. For our purposes, we only care about bundling the CommonJS module corresponding to the Main PureScript module and its transitive dependencies.
-
-The `--main` argument will make the output JavaScript file an executable by adding a line of JavaScript to it which runs the `main` function in the specified module.
-
-If everything worked, you should see about 100 lines of JavaScript printed out. This can optionally be redirected to a file with the `--output`/`-o` argument.
-
-You should be able to execute the generated JavaScript using NodeJS. If your PureScript code uses FFI files which `require` NPM modules, you'll need to use a JavaScript bundler, like Webpack or Browserify, before running it in the browser.
-
-#### Conclusion
-
-I've shown how it's possible to get started with PureScript without using the tools from the NodeJS ecosystem. Obviously, for larger projects, it takes some work to manage library dependencies this way, which is why the PureScript community has decided to reuse existing tools. However, if you need to avoid those tools for any reason, it is possible to script some standard tasks without them.
+If you want to execute this resulting JavaScript in a web browser, you'll need to perform some post-compilation steps, such as bundling. See the [Bundling for a Web Browser guide](guides/Bundling-for-Web-Browser.md) to learn how to do this.


### PR DESCRIPTION
Motivated by https://github.com/purescript/documentation/issues/109

Rather than keeping guides up-to-date, I'd prefer to DRY the docs by directing the reader to follow the "how to do dep management with X" guide.

Also, I think we need an overview of the dependency management options available to PS users.

Bundling was mentioned in that "PS without Node" article. There are many options for doing that, so I'd like to give an overview of the options and give an introduction to each tool in a page for that specific tool.

LMK what you think about this direction.