### PR TITLE
Fix module references to Data.Function.

### DIFF
--- a/guides/FFI-Tips.md
+++ b/guides/FFI-Tips.md
@@ -18,7 +18,7 @@ exports.joinPath = function(start) {
 };
 ```
 
-This is quite tedious and error prone, so there's an alternative representation of function types, `Fn0` up to `Fn10` available from the module `Data.Function` (from [`purescript-functions`](https://github.com/purescript/purescript-functions)). Making use of these types allows us to greatly simplify the previous example:
+This is quite tedious and error prone, so there's an alternative representation of function types, `Fn0` up to `Fn10` available from the module `Data.Function.Uncurried` (from [`purescript-functions`](https://github.com/purescript/purescript-functions)). Making use of these types allows us to greatly simplify the previous example:
 
 ```purescript
 module Path where

--- a/guides/FFI.md
+++ b/guides/FFI.md
@@ -126,7 +126,7 @@ A correct `foreign import` declaration now should use a foreign type whose runti
 ```purescript
 module Interest where
 
-import Data.Function (Fn2)
+import Data.Function.Uncurried (Fn2)
 
 foreign import calculateInterest :: Fn2 Number Number Number
 ```


### PR DESCRIPTION
The types and functions that were under `Data.Function` have been moved to `Data.Function.Uncurried` (see [`purescript-functions`](https://github.com/purescript/purescript-functions)).

This PR updates the documentation to reflect that. There is one other reference in the docs to `Data.Function` in `ImplicitQualifiedImport.md`, but that example doesn't require any functions or types from the module, so I left it as-is.