### PR TITLE
Add docs for PartiallyAppliedSynonym

### DIFF
--- a/errors/PartiallyAppliedSynonym.md
+++ b/errors/PartiallyAppliedSynonym.md
@@ -39,20 +39,23 @@ error = IdentityF (Const 5)
 
 ## Cause
 
-A type alias has been partially applied. To properly use a type alias having type parameters, like `type B a` or `type TypeIdentity a`, you must apply it to a type parameter at every location in the program, like `B Int` or `TypeIdentity Int`.
+A type synonym has been partially applied. To properly use a type synonym having type parameters, like `type B a` or `type TypeIdentity a`, you must apply it to a type parameter at every location in the program, like `B Int` or `TypeIdentity Int`.
 
-A type synonym *can* be partially applied in the context of a type synonym, however. For example:
+To understand the problem, it may be helpful to review the relevant difference between a "type synonym" and a "data type". A type synonym is effectively a macro, a substitution which is performed after parsing into an AST and before type-checking and compilation, while a data type is a proper entity through the compilation process. Because of this, a type synonym has much more restricted use, while a data type enjoys additional flexibility, such as the ability to be partially applied.
+
+Interestingly, a type synonym *can* be partially applied in the context of a type synonym, however. For example:
 
 ```purescript
 type UserT' f = { firstName :: f String }
-newtype UserNT' = UserNT' (UserT' TypeIdentity)
+u' :: UserT' TypeIdentity
+u' = { firstName: "test" }
 ```
 
 ## Fix
 
-Reconsider whether you want to be using a type alias for that particular type declaration. A type synonym is effectively a macro, a substitution which is performed after parsing into an AST and before type-checking and compilation, while a data type exists throughout the compilation process. Because of this, a type synonym has much more restricted use, while a data type enjoys the ability to be partially applied, like a function.
+Reconsider whether you want to use a type synonym for that particular type declaration, or whether to a data type is more appropriate.
 
-In the example above, if you want to use the type alias `TypeIdentity`, you will need to apply it to another type alias to produce a concrete type. That concrete type can then be used in a newtype or a function type signature.
+In the example above, if you want to use the type synonym `TypeIdentity`, you will need to apply it to another type synonym to produce a concrete type. That concrete type can then be used in a newtype or a function type signature.
 
 ```purescript
 type UserT' f = { firstName :: f String }
@@ -64,6 +67,6 @@ um :: UserNT'Maybe
 um = UserNT'Maybe { firstName: Just "test" }
 ```
 
-And to fix the second example, we can't simply fully apply `X`, as that would produce a kind error, `Could not match kind Type -> Type with kind Type`. The `f` in `IdentityF f a` needs to be kind `Type -> Type`, but here it is kind `Type`. The most appropriate solution is to simply use `A` or `B` as the type alias, as demonstrated in `alsoOk` and `alsoAlsoOk`.
+And to fix the second example, we can't simply fully apply `X`, as that would produce a kind error, `Could not match kind Type -> Type with kind Type`. The `f` in `IdentityF f a` needs to be kind `Type -> Type`, but here it is kind `Type`. The most appropriate solution is to simply use `A` or `B` as the type synonym, as demonstrated in `alsoOk` and `alsoAlsoOk`.
 
 ## Notes

--- a/errors/PartiallyAppliedSynonym.md
+++ b/errors/PartiallyAppliedSynonym.md
@@ -10,15 +10,47 @@ type TypeIdentity t = t
 -- The following produces a `PartiallyAppliedSynonym` error.
 u :: UserNT TypeIdentity
 u = UserNT { firstName: "" }
+
+----- Another example
+
+data Const a b = Const a
+data IdentityF f a = IdentityF (f a)
+
+ok :: IdentityF (Const Int) Unit
+ok = IdentityF (Const 5)
+
+-- A, B, and X are all synonyms for the same thing.
+type A = Const
+
+alsoOk :: IdentityF (A Int) Unit
+alsoOk = IdentityF (Const 5)
+
+type B a = Const a
+
+alsoAlsoOk :: IdentityF (B Int) Unit
+alsoAlsoOk = IdentityF (Const 5)
+
+type X a b = Const a b
+
+-- The X type synonym is partially applied here.
+error :: IdentityF (X Int) Unit
+error = IdentityF (Const 5)
 ```
 
 ## Cause
 
-(Please submit an explanation if you have a good one.)
+A type alias has been partially applied. To properly use a type alias having type parameters, like `type B a` or `type TypeIdentity a`, you must apply it to a type parameter at every location in the program, like `B Int` or `TypeIdentity Int`.
+
+A type synonym *can* be partially applied in the context of a type synonym, however. For example:
+
+```purescript
+type UserT' f = { firstName :: f String }
+newtype UserNT' = UserNT' (UserT' TypeIdentity)
+```
 
 ## Fix
 
-Reconsider how you're using type aliases and data types. Using a type alias as if it is a normal data type may cause problems, as it not their intended purpose.
+Reconsider whether you want to be using a type alias for that particular type declaration. A type synonym is effectively a macro, a substitution which is performed after parsing into an AST and before type-checking and compilation, while a data type exists throughout the compilation process. Because of this, a type synonym has much more restricted use, while a data type enjoys the ability to be partially applied, like a function.
 
 In the example above, if you want to use the type alias `TypeIdentity`, you will need to apply it to another type alias to produce a concrete type. That concrete type can then be used in a newtype or a function type signature.
 
@@ -31,5 +63,7 @@ newtype UserNT'Maybe = UserNT'Maybe (UserT' Maybe)
 um :: UserNT'Maybe
 um = UserNT'Maybe { firstName: Just "test" }
 ```
+
+And to fix the second example, we can't simply fully apply `X`, as that would produce a kind error, `Could not match kind Type -> Type with kind Type`. The `f` in `IdentityF f a` needs to be kind `Type -> Type`, but here it is kind `Type`. The most appropriate solution is to simply use `A` or `B` as the type alias, as demonstrated in `alsoOk` and `alsoAlsoOk`.
 
 ## Notes

--- a/errors/PartiallyAppliedSynonym.md
+++ b/errors/PartiallyAppliedSynonym.md
@@ -5,17 +5,33 @@
 ```purescript
 module ShortFailingExample where
 
-...
+newtype UserNT f = UserNT { firstName :: f String }
+type TypeIdentity t = t
+-- The following produces a `PartiallyAppliedSynonym` error.
+u :: UserNT TypeIdentity
+u = UserNT { firstName: "" }
 ```
 
 ## Cause
 
-Explain why a user might see this error.
+A type alias has been replaced with its value, and the result is that an expression has been partially applied.
+
+In the example above, the data type `UserNT` is applied to the type alias `TypeIdentity t`. In the compiler, type aliases are replaced with the underlying type before type-checking, so the type-checker sees a type `UserNT` being applied to a type `t`.
 
 ## Fix
 
-- Suggest possible solutions.
+Reconsider how you're using type aliases and data types. Using a type aliase as if it is a normal data type may cause problems, as it not their intended purpose.
+
+In the example above, if you want to use the type alias `TypeIdentity`, you will need to apply it to another type alias to produce a concrete type. That concrete type can then be used in a newtype or a function type signature.
+
+```purescript
+type UserT' f = { firstName :: f String }
+newtype UserNT' = UserNT' (UserT' TypeIdentity)
+u :: UserNT'
+u = UserNT' { firstName: "test" }
+newtype UserNT'Maybe = UserNT'Maybe (UserT' Maybe)
+um :: UserNT'Maybe
+um = UserNT'Maybe { firstName: Just "test" }
+```
 
 ## Notes
-
-- Additional notes.

--- a/errors/PartiallyAppliedSynonym.md
+++ b/errors/PartiallyAppliedSynonym.md
@@ -14,13 +14,11 @@ u = UserNT { firstName: "" }
 
 ## Cause
 
-A type alias has been replaced with its value, and the result is that an expression has been partially applied.
-
-In the example above, the data type `UserNT` is applied to the type alias `TypeIdentity t`. In the compiler, type aliases are replaced with the underlying type before type-checking, so the type-checker sees a type `UserNT` being applied to a type `t`.
+(Please submit an explanation if you have a good one.)
 
 ## Fix
 
-Reconsider how you're using type aliases and data types. Using a type aliase as if it is a normal data type may cause problems, as it not their intended purpose.
+Reconsider how you're using type aliases and data types. Using a type alias as if it is a normal data type may cause problems, as it not their intended purpose.
 
 In the example above, if you want to use the type alias `TypeIdentity`, you will need to apply it to another type alias to produce a concrete type. That concrete type can then be used in a newtype or a function type signature.
 


### PR DESCRIPTION
Type synonyms can be tricky to compose with data types, and likewise it's tricky to understand this type error. Here's a first draft for it.