### PR TITLE
Remove mention of IO

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@mattaudesse](https://github.com/mattaudesse) | Matt Audesse | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@juhp](https://github.com/juhp) | Jens Petersen | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@gabejohnson](https://github.com/gabejohnson) | Gabe Johnson | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@carstenkoenig](https://github.com/carstenkoenig) | Carsten König | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -62,20 +62,6 @@ PureScript does not provide syntactic sugar for list types. Construct list types
 
 There is also an `Array` type for native JavaScript arrays, but this does not have the same performance characteristics as `List`. `Array` _values_ can be constructed with `[x, y, z]` literals, but the type still needs to be annotated as `Array a`.
 
-## `IO` vs `Effect`
-
-Haskell uses the `IO` monad to deal with side effects. In PureScript, there is a similar monad called `Effect` that serves the same purpose. For example, in a Haskell program the type signature of `main` will be:
-
-``` haskell
-main :: IO ()
-```
-
-In PureScript you would write it like this:
-
-``` purescript
-main :: Effect Unit
-```
-
 ## Records
 
 PureScript can encode JavaScript-style objects directly by using row types, so Haskell-style record definitions actually have quite a different meaning in PureScript:

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -291,7 +291,7 @@ Note on `DataKinds`: Unlike in Haskell, user-defined kinds are open, and they ar
 
 ## `error` and `undefined`
 
-For `error`, you can use `Control.Monad.Eff.Exception.Unsafe.unsafeThrow`, in the `purescript-exceptions` package.
+For `error`, you can use `Effect.Exception.Unsafe.unsafeThrow`, in the `purescript-exceptions` package.
 
 `undefined` can be emulated with `Unsafe.Coerce.unsafeCoerce unit :: forall a. a`, which is in the `purescript-unsafe-coerce` package. See also https://github.com/purescript/purescript-prelude/issues/44.
 


### PR DESCRIPTION
as discussed here https://github.com/purescript/documentation/pull/189#issuecomment-404906508

there is now almost no difference between `IO` and `Effect` so it's not worth mentioning in this document