### PR TITLE
Reorganize guide links, add note about book

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@juhp](https://github.com/juhp) | Jens Petersen | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@gabejohnson](https://github.com/gabejohnson) | Gabe Johnson | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@carstenkoenig](https://github.com/carstenkoenig) | Carsten König | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@anttih](https://github.com/anttih) | Antti Holvikari | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ Feel free to make an issue to discuss amending the scope.
 - [PureScript By Example](https://leanpub.com/purescript/read): A book about PureScript. Learn functional programming for the web by solving practical problems
 - [Try PureScript](http://try.purescript.org): Try PureScript in your browser
 
+## Learning
+
+- The [PureScript Book](https://leanpub.com/purescript/read) is the recommended approach to learning the language, since it covers more material in greater depth. However, it is not updated yet for the 0.12 version of the compiler.
+- [Language Reference](language/README.md)
+
+## Guides
+
+- [Common Operators](guides/Common-Operators.md)
+- [The Foreign Function Interface (FFI)](guides/FFI.md)
+- [FFI Tips](guides/FFI-Tips.md)
+- [Generic Programming](guides/Generic.md)
+- [Handling Native Effects with the Eff Monad](guides/Eff.md)
+- [Test your JavaScript with QuickCheck](guides/QuickCheck.md)
+- [Custom Type Errors](guides/Custom-Type-Errors.md)
+- [PureScript Without Node](guides/PureScript-Without-Node.md)
+- [Contrib Library Guidelines](guides/Contrib-Guidelines.md)
+- [Error Suggestions](guides/Error-Suggestions.md)
+- [psc-ide FAQ](guides/psc-ide-FAG.md)
+- [The `Partial` type class](guides/The-Partial-type-class.md)
+- [Try PureScript Help](https://github.com/purescript/trypurescript/blob/gh-pages/README.md)
+
+
 ## Tools
 
 - [Editor and tool support](ecosystem/Editor-and-tool-support.md): Editor plugins, build tools, and other development tools
@@ -45,28 +67,12 @@ Feel free to make an issue to discuss amending the scope.
 
 ## Articles
 
-- [Common Operators](guides/Common-Operators.md)
-- [The Foreign Function Interface (FFI)](guides/FFI.md)
-- [FFI Tips](guides/FFI-Tips.md)
-- [Generic Programming](guides/Generic.md)
-- [Handling Native Effects with the Eff Monad](guides/Eff.md)
-- [Test your JavaScript with QuickCheck](guides/QuickCheck.md)
-- [Custom Type Errors](guides/Custom-Type-Errors.md)
-- [PureScript Without Node](guides/PureScript-Without-Node.md)
 - [24 Days of PureScript 2016](https://github.com/paf31/24-days-of-purescript-2016)
-- [Try PureScript Help](https://github.com/purescript/trypurescript/blob/gh-pages/README.md)
-- [More Guides](guides/)
 
 ## Talks/Meetups
 
 - [PureScript Presentations](ecosystem/PureScript-Presentations.md)
 - [PureScript Meetups](ecosystem/PureScript-Meetups.md)
-
-## Language Guides
-
-The [PureScript Book](https://leanpub.com/purescript/read) is the recommended approach to learning the language, since it covers more material in greater depth. There is also a language guide, which is more useful as a reference:
-
-- [Language Reference](language/README.md)
 
 ## Related Languages
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Feel free to make an issue to discuss amending the scope.
 - [PureScript Without Node](guides/PureScript-Without-Node.md)
 - [Contrib Library Guidelines](guides/Contrib-Guidelines.md)
 - [Error Suggestions](guides/Error-Suggestions.md)
-- [psc-ide FAQ](guides/psc-ide-FAG.md)
+- [psc-ide FAQ](guides/psc-ide-FAQ.md)
 - [The `Partial` type class](guides/The-Partial-type-class.md)
 - [Try PureScript Help](https://github.com/purescript/trypurescript/blob/gh-pages/README.md)
 


### PR DESCRIPTION
* Rename "Articles" heading to "Guides"
* Move guides section and book link right after the getting started part
* Add missing links to guides section and remove "More guides" link
* Add note about book not being updated yet for 0.12