### PR TITLE
Move PyreScript to stale

### DIFF
--- a/ecosystem/Alternate-backends.md
+++ b/ecosystem/Alternate-backends.md
@@ -12,7 +12,6 @@ There are various alternatives to `psc`'s default JavaScript backend:
 | source code                                                                             | PS version | Target        | 
 |:----------------------------------------------------------------------------------------|:-----------|:--------------|
 | [andyarvanitis/purescript-clojure](https://github.com/andyarvanitis/purescript-clojure) |            | Clojure (JVM) |
-| [PyreScript](https://github.com/joneshf/pyrescript)                                     | 0.9.1      | Python        |
 | [epost/psc-query](https://github.com/epost/psc-query)                                   | 0.7.3.0    | Datalog       |
 | [tfausak/thran](https://github.com/tfausak/thran)                                       | 0.11.6     | Haskell (GHC) |
 
@@ -24,3 +23,4 @@ There are various alternatives to `psc`'s default JavaScript backend:
 | [slamdata/truffled-purescript](https://github.com/slamdata/truffled-purescript)       | 0.7.5.x    | Truffle (JVM) |
 | [osa1/psc-lua](https://github.com/osa1/psc-lua)                                       | 0.5.x      | Lua           |
 | [Gabriel439/Purescript-to-Python](https://github.com/Gabriel439/Purescript-to-Python) |            | Python        |
+| [PyreScript](https://github.com/joneshf/pyrescript)                                   | 0.9.1      | Python        |


### PR DESCRIPTION
It's three major versions behind, and I've no interest in updating it at this point.
Seems like it's stale to me.