### PR TITLE
Re-organize readme (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,62 @@ To get a better overview of PureScript, visit [The PureScript Website](http://pu
 
 This repository is a collaborative effort, so please feel free to make a pull request to add/edit content or create an issue to discuss it. PureScript is a big project used by people coming from a variety of backgrounds. Making documentation useful to a wide variety of people is really hard to do well, requiring readers like you to point out and add documentation you feel is missing. Thanks for helping!
 
+## Directory
+
+### Getting Started
+
+- [Getting Started](guides/Getting-Started.md): Download PureScript and build your first project
+- [PureScript By Example](https://leanpub.com/purescript/read): A book about PureScript. Learn functional programming for the web by solving practical problems
+- [Try PureScript](http://try.purescript.org): Try PureScript in your browser
+
+### Learning
+
+- The [PureScript Book](https://leanpub.com/purescript/read) is the recommended approach to learning the language, since it covers more material in greater depth. However, it is not updated yet for the 0.12 version of the compiler.
+- [Language Reference](language/README.md)
+- [PureScript: Jordan's Reference](https://github.com/JordanMartinez/purescript-jordans-reference): An up-to-date project covering Getting Started, Build Tools, PureScript's syntax with examples, FP design patterns, and PureScript's ecosystem.
+
+### Guides
+
+- [Common Operators](guides/Common-Operators.md)
+- [The Foreign Function Interface (FFI)](guides/FFI.md)
+- [FFI Tips](guides/FFI-Tips.md)
+- [Generic Programming](guides/Generic.md)
+- [Handling Native Effects with the Eff Monad](guides/Eff.md)
+- [Custom Type Errors](guides/Custom-Type-Errors.md)
+- [PureScript Without Node](guides/PureScript-Without-Node.md)
+- [Contrib Library Guidelines](guides/Contrib-Guidelines.md)
+- [Error Suggestions](guides/Error-Suggestions.md)
+- [psc-ide FAQ](guides/psc-ide-FAQ.md)
+- [The `Partial` type class](guides/The-Partial-type-class.md)
+- [Try PureScript Help](https://github.com/purescript/trypurescript/blob/gh-pages/README.md)
+
+
+### Tools
+
+- [Editor and tool support](ecosystem/Editor-and-tool-support.md): Editor plugins, build tools, and other development tools
+- [PureScript and NixOS](https://pr06lefs.wordpress.com/2015/01/11/get-started-with-purescript-on-nixos/): How to use PureScript with NixOS
+- [PSCi](guides/PSCi.md): An interactive development tool for PureScript
+
+### Ecosystem
+
+- [Maintained Packages](ecosystem/Maintained-Packages.md)
+- [Style Guide](guides/Style-Guide.md)
+- [Alternate Backends](https://github.com/purescript/documentation/blob/master/ecosystem/Alternate-backends.md): PureScript can compile to other languages as well!
+
+### Articles
+
+- [24 Days of PureScript 2016](https://github.com/paf31/24-days-of-purescript-2016)
+
+### Talks/Meetups
+
+- [PureScript Presentations](ecosystem/PureScript-Presentations.md)
+- [PureScript Meetups](ecosystem/PureScript-Meetups.md)
+
+### Related Languages
+
+- [Related Projects](Related-Projects.md)
+- [Differences from Haskell](language/Differences-from-Haskell.md)
+
 ## Project Scope
 
 Topics currently in this repository's scope:
@@ -24,57 +80,3 @@ Topics currently *not* in scope:
 - A PureScript language teaching course (use the [PureScript by Example](https://leanpub.com/purescript/read) book or other resources)
 
 Feel free to make an issue to discuss amending the scope.
-
-## Getting Started
-
-- [Getting Started](guides/Getting-Started.md): Download PureScript and build your first project
-- [PureScript By Example](https://leanpub.com/purescript/read): A book about PureScript. Learn functional programming for the web by solving practical problems
-- [Try PureScript](http://try.purescript.org): Try PureScript in your browser
-
-## Learning
-
-- The [PureScript Book](https://leanpub.com/purescript/read) is the recommended approach to learning the language, since it covers more material in greater depth. However, it is not updated yet for the 0.12 version of the compiler.
-- [Language Reference](language/README.md)
-- [PureScript: Jordan's Reference](https://github.com/JordanMartinez/purescript-jordans-reference): An up-to-date project covering Getting Started, Build Tools, PureScript's syntax with examples, FP design patterns, and PureScript's ecosystem.
-
-## Guides
-
-- [Common Operators](guides/Common-Operators.md)
-- [The Foreign Function Interface (FFI)](guides/FFI.md)
-- [FFI Tips](guides/FFI-Tips.md)
-- [Generic Programming](guides/Generic.md)
-- [Handling Native Effects with the Eff Monad](guides/Eff.md)
-- [Custom Type Errors](guides/Custom-Type-Errors.md)
-- [PureScript Without Node](guides/PureScript-Without-Node.md)
-- [Contrib Library Guidelines](guides/Contrib-Guidelines.md)
-- [Error Suggestions](guides/Error-Suggestions.md)
-- [psc-ide FAQ](guides/psc-ide-FAQ.md)
-- [The `Partial` type class](guides/The-Partial-type-class.md)
-- [Try PureScript Help](https://github.com/purescript/trypurescript/blob/gh-pages/README.md)
-
-
-## Tools
-
-- [Editor and tool support](ecosystem/Editor-and-tool-support.md): Editor plugins, build tools, and other development tools
-- [PureScript and NixOS](https://pr06lefs.wordpress.com/2015/01/11/get-started-with-purescript-on-nixos/): How to use PureScript with NixOS
-- [PSCi](guides/PSCi.md): An interactive development tool for PureScript
-
-## Ecosystem
-
-- [Maintained Packages](ecosystem/Maintained-Packages.md)
-- [Style Guide](guides/Style-Guide.md)
-- [Alternate Backends](https://github.com/purescript/documentation/blob/master/ecosystem/Alternate-backends.md): PureScript can compile to other languages as well!
-
-## Articles
-
-- [24 Days of PureScript 2016](https://github.com/paf31/24-days-of-purescript-2016)
-
-## Talks/Meetups
-
-- [PureScript Presentations](ecosystem/PureScript-Presentations.md)
-- [PureScript Meetups](ecosystem/PureScript-Meetups.md)
-
-## Related Languages
-
-- [Related Projects](Related-Projects.md)
-- [Differences from Haskell](language/Differences-from-Haskell.md)


### PR DESCRIPTION
An attempt at moving the "project scope" section to the bottom while indicating that it exists by indenting the other sections in the readme