### PR TITLE
Revert "fixed wrong type signature (#245)"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,6 +53,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@soupi](https://github.com/soupi) | Gil Mizrahi | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@FungusHumungus](https://github.com/FungusHumungus) | Stephen Wakely | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@Beyarz](https://github.com/Beyarz) | Beyar N | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@bernhard-herzog](https://github.com/bernhard-herzog) | Bernhard Herzog | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 

--- a/language/Types.md
+++ b/language/Types.md
@@ -194,7 +194,7 @@ combineBar f o = f o.foo o.bar
 type Baz = Number -> Number -> Bar Number
 
 -- This function will take two arguments and return a record with double the value
-mkDoubledFoo :: Number -> Number -> Baz
+mkDoubledFoo :: Baz
 mkDoubledFoo foo bar = { foo: 2.0*foo, bar: 2.0*bar }
 
 -- Build on our previous functions to double the values inside any Foo


### PR DESCRIPTION
This reverts commit 13725a0531cc2b9d55f574508b440a67f9cace28.

The type signature that was changed by #245 was actually correct
before that PR, see
https://github.com/purescript/documentation/pull/245#issuecomment-472020050