### PR TITLE
Fix: broken link in MissingTypeDeclaration.md

### DIFF
--- a/errors/MissingTypeDeclaration.md
+++ b/errors/MissingTypeDeclaration.md
@@ -28,7 +28,7 @@ main = log "A type annotation has been provided!"
 
 ## Notes
 
-Many of [the PureScript text editor plugins](ecosystem/Editor-and-tool-support.md) can save you the effort of writing type annotations by filling in the types for you.
+Many of [the PureScript text editor plugins](/ecosystem/Editor-and-tool-support.md) can save you the effort of writing type annotations by filling in the types for you.
 
 Declarations which are not at the top level, such as those contained within `let` or `where` clauses, are not considered as important to annotate with types, and so the compiler does not issue warnings when these declarations are not annotated.  The following example compiles without warnings, even though `message` has not been given a type annotation:
 


### PR DESCRIPTION
👋 

Just a tiny little change, I think the relative link was broken due to a missing prepended `/`.