### PR TITLE
Remove duplicate PureScript by Example book link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,6 +65,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@AidanDelaney](https://github.com/AidanDelaney) | Aidan Delaney | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@BebeSparkelSparkel](https://github.com/BebeSparkelSparkel) | William Rusnack | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@archaeron](https://github.com/archaeron) | archaeron | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@milesfrain](https://github.com/milesfrain) | Miles Frain | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This repository is a collaborative effort, so please feel free to make a pull re
 ### Getting Started
 
 - [Getting Started](guides/Getting-Started.md): Download PureScript and build your first project
-- [PureScript By Example](https://leanpub.com/purescript/read): A book about PureScript. Learn functional programming for the web by solving practical problems
 - [Try PureScript](http://try.purescript.org): Try PureScript in your browser
 
 ### Learning


### PR DESCRIPTION
New users may see `PureScript By Example` and `PureScript Book` as two separate resources.

Even if these links are renamed to match, new users could still miss the warning in **Learning** if they dive straight into **Getting Started**.

It may be best to just remove `PureScript By Example` from the getting started section, or merge both sections.