### PR TITLE
Include <#> notes to Differences-from-Haskell.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,6 +66,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@BebeSparkelSparkel](https://github.com/BebeSparkelSparkel) | William Rusnack | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@archaeron](https://github.com/archaeron) | archaeron | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@milesfrain](https://github.com/milesfrain) | Miles Frain | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@GCrispino](https://github.com/gcrispino) | Gabriel Crispino | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -307,6 +307,7 @@ As PureScript has not inherited Haskell's legacy code, some operators and functi
 
 - `(>>)` is `(*>)`, as `Apply` is a superclass of `Monad` so there is no need to have an `Monad`-specialised version.
 - Since 0.9.1, the `Prelude` library does not contain `(++)` as a second alias for `append` / `(<>)` (`mappend` in Haskell) anymore.
+- Haskell's `<&>` operator (from `Data.Functor`) is equivalent to Purescript's `<#>` (operator alias to `mapFlipped`).
 - `mapM` is `traverse`, as this is a more general form that applies to any traversable structure, not just lists. Also it only requires `Applicative` rather than `Monad`. Similarly, `liftM` is `map`.
 - Many functions that are part of `Data.List` in Haskell are provided in a more generic form in `Data.Foldable` or `Data.Traversable`.
 - `some` and `many` are defined with the type of list they operate on (`Data.Array` or `Data.List`).


### PR DESCRIPTION
This PR just adds a note for the Purescript's <#> operator to Differences-from-Haskell.md (https://github.com/purescript/documentation/issues/284). Since it is equivalent to Haskell's <&> this can be a source of confusion (it was to me).

I'm open to suggestions. Thanks!