### PR TITLE
Add documentation for `DeprecatedFFIPrime` warnings

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,6 +67,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@archaeron](https://github.com/archaeron) | archaeron | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@milesfrain](https://github.com/milesfrain) | Miles Frain | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@GCrispino](https://github.com/gcrispino) | Gabriel Crispino | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 

--- a/errors/DeprecatedFFIPrime.md
+++ b/errors/DeprecatedFFIPrime.md
@@ -1,0 +1,33 @@
+# `DeprecatedFFIPrime` Warning
+
+## Example
+
+```javascript
+exports["example'"] = 0;
+```
+
+```purescript
+module ShortFailingExample where
+
+foreign import example' :: Int
+```
+
+## Cause
+
+An identifier imported from a foreign module contains a prime (`'`) character.
+
+## Fix
+
+Remove the prime from the identifier:
+
+```diff
+-exports["example'"] = 0;
++exports.example = 0;
+```
+
+```diff
+module ShortFailingExample where
+
+-foreign import example' :: Int
++foreign import example :: Int
+```


### PR DESCRIPTION
This PR documents the warning that will be emitted for foreign identifiers containing primes once https://github.com/purescript/purescript/pull/3792 is merged.