### PR TITLE
Replace references to pulp with spago in error docs

### DIFF
--- a/errors/CycleInDeclaration.md
+++ b/errors/CycleInDeclaration.md
@@ -3,7 +3,7 @@
 ## Example
 
 ```text
-$ pulp repl
+$ spago repl
 
 > x = x
 Error found:

--- a/errors/ModuleNotFound.md
+++ b/errors/ModuleNotFound.md
@@ -21,6 +21,6 @@ Check that:
 
 - you have spelled the name of the module correctly,
 - if the module comes from a library, that you have installed that library in your project,
-- you have supplied the filename of the module to `purs build` on the command line (note that build tools, such as `webpack` or `pulp`, should generally take care of this for you; if in doubt, check their documentation).
+- you have supplied the filename of the module to `purs build` on the command line (note that build tools, such as `webpack`, `parcel` or `spago`, should generally take care of this for you; if in doubt, check their documentation).
 
 If you know which module you are looking for but are unsure which library it comes from, you can search for it on <https://pursuit.purescript.org>.


### PR DESCRIPTION
Updates error docs to use `spago` instead of `pulp` for consistency across all docs.