### PR TITLE
Fix pure documentation link

### DIFF
--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -205,7 +205,7 @@ The `<<<` operator is actually a more general morphism composition operator that
 
 ## `return`
 
-In the past, PureScript used `return`. However, it is now removed and replaced with [`pure`](https://pursuit.purescript.org/packages/purescript-prelude/1.1.0/docs/Control.Applicative#v:pure). It was always an alias for `pure`, which means this change was implemented by simply removing the alias.
+In the past, PureScript used `return`. However, it is now removed and replaced with [`pure`](https://pursuit.purescript.org/packages/purescript-prelude/docs/Control.Applicative#v:pure). It was always an alias for `pure`, which means this change was implemented by simply removing the alias.
 
 ## Array Comprehensions
 


### PR DESCRIPTION
This change removes the version number from the prelude documentation
link to prevent referencing missing page.