### PR TITLE
Add type declaration to test file to supress warnings

### DIFF
--- a/guides/Getting-Started.md
+++ b/guides/Getting-Started.md
@@ -202,9 +202,11 @@ module Test.Main where
 
 import Prelude
 
+import Effect (Effect)
 import Euler (answer)
 import Test.Assert (assert)
 
+main :: Effect Unit
 main = do
   assert (answer == 233168)
 ```


### PR DESCRIPTION
On the current version of purescript, omitting a type declaration for the
top-level declaration of main emits an MissingTypeDeclaration error. This
prevents that.