### PR TITLE
Update PureScript book reference to point to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ This repository is a collaborative effort, so please feel free to make a pull re
 
 ### Learning
 
-- The [PureScript Book](https://leanpub.com/purescript/read) is the recommended approach to learning the language, since it covers more material in greater depth. However, it covers `0.11.7` and is not updated yet for the `0.12.x` version of the compiler. Thus, one should be aware of the following materials when reading through the book:
-    - See [dwhitney's fork of the book's exercises](https://github.com/dwhitney/purescript-book) which is updated for `0.12.x`.
-    - See [Justin's `0.11.7` to `0.12.x` summary](https://purescript-resources.readthedocs.io/en/latest/0.11.7-to-0.12.0.html) to know how to 'translate' the outdated book's code into working code.
-    - Be wary of any references to these [deprecated packages](https://github.com/purescript-deprecated) in the book.
+- The [PureScript Book](https://book.purescript.org) is the recommended approach to learning the language, since it covers more material in greater depth. However, it is currently being updated from the `0.11.7` version of the PureScript compiler to the `0.13.x` version.
 - [Language Reference](language/README.md)
 - [PureScript: Jordan's Reference](https://github.com/JordanMartinez/purescript-jordans-reference): An up-to-date project covering Getting Started, Build Tools, PureScript's syntax with examples, FP design patterns, and PureScript's ecosystem.
 - [A guide to the PureScript numeric hierarchy](https://a-guide-to-the-purescript-numeric-hierarchy.readthedocs.io/en/latest/index.html): An introduction to the mathematics behind the numeric hierarchy of type classes in PureScript’s Prelude. (See also [PureScript numeric hierarchy overview](https://harry.garrood.me/numeric-hierarchy-overview/).)


### PR DESCRIPTION
For context, see purescript-contrib/purescript-book#73

Note: don't merge this until the `index.html` file in that repo has been moved to the correct location.