### PR TITLE
Point Book Links to book.purescript.org

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,7 +68,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@milesfrain](https://github.com/milesfrain) | Miles Frain | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@GCrispino](https://github.com/gcrispino) | Gabriel Crispino | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
-| [@kl0tl](https://github.com/kurtmilam) | Kurt Milam | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@kurtmilam](https://github.com/kurtmilam) | Kurt Milam | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,6 +68,7 @@ If you would prefer to use different terms, please use the section below instead
 | [@milesfrain](https://github.com/milesfrain) | Miles Frain | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@GCrispino](https://github.com/gcrispino) | Gabriel Crispino | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 | [@kl0tl](https://github.com/kl0tl) | Cyril Sobierajewicz | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
+| [@kl0tl](https://github.com/kurtmilam) | Kurt Milam | [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/deed) |
 
 ### Contributors using Modified Terms
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Topics currently in this repository's scope:
 Topics currently *not* in scope:
 
 - Using PureScript libraries (those docs belong with the corresponding libraries)
-- A PureScript language teaching course (use the [PureScript by Example](https://leanpub.com/purescript/read) book or other resources)
+- A PureScript language teaching course (use the [PureScript by Example](https://book.purescript.org) book or other resources)
 - Introduction to package managers and dependency management
 
 Feel free to make an issue to discuss amending the scope.

--- a/guides/FFI-Tips.md
+++ b/guides/FFI-Tips.md
@@ -117,7 +117,7 @@ By moving the `show` reference out to `showSomething` the compiler will pick the
 
 ## Why Doesn't my `Eff` Work When Passed to a Normal JS Function?
 
-["Representing Side Effects"](https://book.purescript.org/chapter8.html#the-effect-monad-1) in *PureScript by Example*.
+["Representing Side Effects"](https://book.purescript.org/chapter10.html#representing-side-effects) in *PureScript by Example*.
 
 In order to avoid prematurely evaluating effects (or evaluating effects that should not be evaluated at all), PureScript wraps them in constant functions:
 

--- a/guides/FFI-Tips.md
+++ b/guides/FFI-Tips.md
@@ -117,7 +117,7 @@ By moving the `show` reference out to `showSomething` the compiler will pick the
 
 ## Why Doesn't my `Eff` Work When Passed to a Normal JS Function?
 
-["Representing Side Effects"](https://leanpub.com/purescript/read#leanpub-auto-representing-side-effects) in *PureScript by Example*.
+["Representing Side Effects"](https://book.purescript.org/chapter8.html#the-effect-monad-1) in *PureScript by Example*.
 
 In order to avoid prematurely evaluating effects (or evaluating effects that should not be evaluated at all), PureScript wraps them in constant functions:
 

--- a/guides/FFI.md
+++ b/guides/FFI.md
@@ -232,4 +232,4 @@ Developers who define their own foreign data types should take care to document 
 
 I have hopefully shown that interoperating with Javascript is simple in both directions, once a few small implementation details are understood. You should now be able to wrap your Javascript libraries for use in PureScript, and vice versa.
 
-The [PureScript book](https://leanpub.com/purescript/read#leanpub-auto-the-foreign-function-interface) contains more information on the FFI, and plenty of examples and exercises for any interested readers.
+The [PureScript book](https://book.purescript.org/chapter10.html) contains more information on the FFI, and plenty of examples and exercises for any interested readers.

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -55,7 +55,7 @@ main = do
 
 ## Multi-Parameter Type Classes
 
-TODO. For now, see the section in [PureScript by Example](https://leanpub.com/purescript/read#leanpub-auto-multi-parameter-type-classes).
+TODO. For now, see the section in [PureScript by Example](https://book.purescript.org/chapter6.html#multi-parameter-type-classes).
 
 ## Superclasses
 
@@ -126,7 +126,7 @@ The `|` symbol marks the beginning of functional dependencies, which are separat
 
 Functional dependencies are especially useful with the various `Prim` typeclasses, such as `Prim.Row.Cons`: https://pursuit.purescript.org/builtins/docs/Prim.Row#t:Cons
 
-See also the section in [PureScript by Example](https://leanpub.com/purescript/read#leanpub-auto-functional-dependencies).
+See also the section in [PureScript by Example](https://book.purescript.org/chapter6.html#functional-dependencies).
 
 ## Type Class Deriving
 


### PR DESCRIPTION
This PR updates five links to "PureScript by Example", pointing them at [book.purescript.org](https://book.purescript.org) rather than leanpub.

Related issue: https://github.com/purescript/documentation/issues/315