### PR TITLE
Update Getting-Started.md

### DIFF
--- a/guides/Getting-Started.md
+++ b/guides/Getting-Started.md
@@ -16,7 +16,7 @@ The Purescript compiler (`purs`) can be installed with npm:
 
 #### Setting up the Development Environment
 
-PureScript's core libraries are configured to use the [Spago](https://github.com/spacchetti/spago) package manager and build tool.
+[Spago](https://github.com/spacchetti/spago) is the recommended package manager and build tool for PureScript.
 
 If you don't have Spago installed, install it now:
 


### PR DESCRIPTION
This sentence is a bit misleading as currently stated:

- the core libraries generally don't use Spago at the moment;
- this sentence implies that we have to follow what the core libraries do, which isn't true. In fact the matter of how the core libraries are set up is not relevant here at all.