### PR TITLE
Add derive via Generic example, and point to latest docs

### DIFF
--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -145,7 +145,7 @@ newtype Person = Person { name :: String, age :: Int }
 derive instance eqPerson :: Eq Person
 derive instance ordPerson :: Ord Person
 ```
-Currently, the following type classes can be derived:
+Currently, the following type classes can be derived by the compiler:
 
 - [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-generics-rep/docs/Data.Generic.Rep#t:Generic)
 - [Data.Eq (class Eq)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Eq#t:Eq)
@@ -153,7 +153,8 @@ Currently, the following type classes can be derived:
 - [Data.Functor (class Functor)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Functor#t:Functor)
 - [Data.Newtype (class Newtype)](https://pursuit.purescript.org/packages/purescript-newtype/docs/Data.Newtype#t:Newtype)
 
-Other type classes may be derived via `Generic`:
+Note that `derive instance` is not the only mechanism for allowing you to avoid writing out boilerplate type class instance code. Many type classes not listed here can be derived through other means, such as via a Generic instance. For example, here's how to create a `Show` instance for `Person` via `genericShow`:
+
 ```purescript
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
@@ -163,6 +164,8 @@ derive instance genericPerson :: Generic Person _
 instance showPerson :: Show Person where
   show = genericShow
 ```
+
+More information on Generic deriving is available [in the generics-rep library documentation](https://pursuit.purescript.org/packages/purescript-generics-rep).
 
 ## Compiler-Solvable Type Classes
 

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -147,11 +147,22 @@ derive instance ordPerson :: Ord Person
 ```
 Currently, the following type classes can be derived:
 
-- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-generics-rep/6.0.0/docs/Data.Generic.Rep#t:Generic)
-- [Data.Eq (class Eq)](https://pursuit.purescript.org/packages/purescript-prelude/4.1.0/docs/Data.Eq#t:Eq)
-- [Data.Ord (class Ord)](https://pursuit.purescript.org/packages/purescript-prelude/4.1.0/docs/Data.Ord#t:Ord)
-- [Data.Functor (class Functor)](https://pursuit.purescript.org/packages/purescript-prelude/4.1.0/docs/Data.Functor#t:Functor)
-- [Data.Newtype (class Newtype)](https://pursuit.purescript.org/packages/purescript-newtype/3.0.0/docs/Data.Newtype#t:Newtype)
+- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-generics-rep/docs/Data.Generic.Rep#t:Generic)
+- [Data.Eq (class Eq)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Eq#t:Eq)
+- [Data.Ord (class Ord)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Ord#t:Ord)
+- [Data.Functor (class Functor)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Functor#t:Functor)
+- [Data.Newtype (class Newtype)](https://pursuit.purescript.org/packages/purescript-newtype/docs/Data.Newtype#t:Newtype)
+
+Other type classes may be derived via `Generic`:
+```purescript
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+
+derive instance genericPerson :: Generic Person _
+
+instance showPerson :: Show Person where
+  show = genericShow
+```
 
 ## Compiler-Solvable Type Classes
 


### PR DESCRIPTION
I often visit this page looking for a `genericShow` example.

It was also frustrating to click on the `Data.Generic.Rep` and be taken to an older package version that's missing lots of nice documentation. So ensuring links now go to the latest version. (related to https://github.com/purescript/pursuit/issues/414)