### PR TITLE
Clarify intended audience of the language reference folder

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -1,5 +1,7 @@
 # PureScript Language Reference
 
+**Note:** the `language` folder's content is primarily for intermediate users already familiar with the language. It serves to help such users determine whether an issue they are experiencing is intended behavior or caused by a bug. It is not meant for people who are learning PureScript for the first time.
+
 As an introductory example, here is the usual "Hello World" written in PureScript:
 
 ```purescript


### PR DESCRIPTION
Per [Harry's comment about this](https://github.com/purescript/documentation/issues/345#issuecomment-678812487), this PR adds a note that the `language` folder's content is not intended for those learning PureScript for the first time.

I could also update the project's readme to clarify that in the [Learning section](https://github.com/purescript/documentation/#learning), but I'll wait for further guidance as to how to do that before doing the work. For example, should I include a note near that link that clarifies that? Should the link be relocated to somewhere else on this repo?