### PR TITLE
Add missing errors placeholders

### DIFF
--- a/errors/CannotDefinePrimModules.md
+++ b/errors/CannotDefinePrimModules.md
@@ -1,0 +1,24 @@
+# `CannotDefinePrimModules` Error
+
+## Example
+
+```purescript
+module Prim where
+```
+
+```purescript
+module Prim.ShortFailingExample where
+```
+
+## Cause
+
+The Prim namespace is reserved by the compiler.
+
+## Fix
+
+- Rename the module to move it outside the Prim namespace:
+
+```diff
+-module Prim.ShortFailingExample where
++module ShortFailingExample where
+```

--- a/errors/CycleInTypeClassDeclaration.md
+++ b/errors/CycleInTypeClassDeclaration.md
@@ -1,0 +1,21 @@
+# `CycleInTypeClassDeclaration` Error
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this error.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/DuplicateInstance.md
+++ b/errors/DuplicateInstance.md
@@ -1,0 +1,21 @@
+# `DuplicateInstance` Error
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this error.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/DuplicateTypeClass.md
+++ b/errors/DuplicateTypeClass.md
@@ -1,0 +1,21 @@
+# `DuplicateTypeClass` Error
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this error.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/ErrorParsingCSTModule.md
+++ b/errors/ErrorParsingCSTModule.md
@@ -1,0 +1,21 @@
+# `ErrorParsingCSTModule` Error
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this error.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/ExpectedTypeConstructor.md
+++ b/errors/ExpectedTypeConstructor.md
@@ -1,0 +1,21 @@
+# `ExpectedTypeConstructor` Error
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this error.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/ImplicitQualifiedImportReExport.md
+++ b/errors/ImplicitQualifiedImportReExport.md
@@ -1,0 +1,21 @@
+# `ImplicitQualifiedImportReExport` Warning
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this warning.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/InvalidDerivedInstance.md
+++ b/errors/InvalidDerivedInstance.md
@@ -1,0 +1,21 @@
+# `InvalidDerivedInstance` Error
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this error.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/MissingKindDeclaration.md
+++ b/errors/MissingKindDeclaration.md
@@ -1,0 +1,21 @@
+# `MissingKindDeclaration` Warning
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this warning.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/MissingNewtypeSuperclassInstance.md
+++ b/errors/MissingNewtypeSuperclassInstance.md
@@ -1,0 +1,21 @@
+# `MissingNewtypeSuperclassInstance` Warning
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this warning.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/UnusableDeclaration.md
+++ b/errors/UnusableDeclaration.md
@@ -1,0 +1,21 @@
+# `UnusableDeclaration` Error
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this error.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.

--- a/errors/UnverifiableSuperclassInstance.md
+++ b/errors/UnverifiableSuperclassInstance.md
@@ -1,0 +1,21 @@
+# `UnverifiableSuperclassInstance` Warning
+
+## Example
+
+```purescript
+module ShortFailingExample where
+
+...
+```
+
+## Cause
+
+Explain why a user might see this warning.
+
+## Fix
+
+- Suggest possible solutions.
+
+## Notes
+
+- Additional notes.


### PR DESCRIPTION
This adds placeholders for the missing errors identified by @nwolverson in https://github.com/purescript/documentation/issues/36#issuecomment-355357400, @jamesdbrock in https://github.com/purescript/documentation/issues/36#issuecomment-614986935 and also for `CannotDefinePrimModules`, `CycleInTypeClassDeclaration`, `ErrorParsingCSTModule`, `ImplicitQualifiedImportReExport` and `MissingKindDeclaration`.