### PR TITLE
Document `CannotFindCoercedCtor` and `CannotFindCoercedNewtypeCtor`

### DIFF
--- a/errors/CannotFindCoercedCtor.md
+++ b/errors/CannotFindCoercedCtor.md
@@ -1,0 +1,32 @@
+# `CannotFindCoercedCtor` Error
+
+## Example
+
+```purescript
+module N (N) where
+
+newtype N a = N a
+```
+
+```purescript
+module ShortFailingExample where
+
+import Safe.Coerce (coerce)
+import N
+
+example :: forall a. a -> N a
+example = coerce
+```
+
+## Cause
+
+Newtype constructors have to be in scope to allow coercions to and from their representation.
+
+## Fix
+
+- Export the newtype constructor:
+
+```diff
+-module N (N) where
++module N (N(..)) where
+```

--- a/errors/CannotFindCoercedNewtypeCtor.md
+++ b/errors/CannotFindCoercedNewtypeCtor.md
@@ -1,0 +1,32 @@
+# `CannotFindCoercedNewtypeCtor` Error
+
+## Example
+
+```purescript
+module N (N(..)) where
+
+newtype N a = N a
+```
+
+```purescript
+module ShortFailingExample where
+
+import Safe.Coerce (coerce)
+import N (N)
+
+example :: forall a. a -> N a
+example = coerce
+```
+
+## Cause
+
+Newtype constructors have to be in scope to allow coercions to and from their representation.
+
+## Fix
+
+- Import the newtype constructor:
+
+```diff
+-import N (N)
++import N (N(..))
+```


### PR DESCRIPTION
This pull request documents the `CannotFindCoercedConstructor` error introduced by https://github.com/purescript/purescript/pull/3927.