### PR TITLE
Update InvalidFFIIdentifier warning

### DIFF
--- a/errors/InvalidFFIIdentifier.md
+++ b/errors/InvalidFFIIdentifier.md
@@ -10,12 +10,14 @@ module ShortFailingExample where
 
 ## Cause
 
-Explain why a user might see this error.
+- The exported identifier might not be a valid purescript identifer.
+- Suggest other causes.
 
 ## Fix
 
-- Suggest possible solutions.
+- Purescript identifiers must start with a lowercase character or `_`.
 
 ## Notes
 
-- Additional notes.
+- See the lexing rules here: https://github.com/purescript/purescript/blob/fe67ac07e9cac1d361a716740d8c82020b7a1214/lib/purescript-cst/src/Language/PureScript/CST/Lexer.hs#L684
+


### PR DESCRIPTION
Hi,

I'm new to purescript. I was attempting to find a migration strategy from typescript to purescript for our codebase.
I had typescript transpile to `CommonJS` so it generates `exports.identifier = ...` so I can create FFIs.
However, I got this warning. It took me some time to figure out it was casing.

* A suggested cause is an invalid identifier
* Suggested fix is casing on the initial character or `_`
* I suggested looking at the lexer in the notes because I wasn't sure where to find those rules elsewhere. Maybe there's another resource someone can point to.