### PR TITLE
Remove Monoid Semigroup Superclass Example

### DIFF
--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -188,7 +188,6 @@ At the moment, it is not possible to declare default member implementations for 
 Many type class hierarchies are more granular than in Haskell. For example:
 
 * `Category` has a superclass `Semigroupoid` which provides `(<<<)`, and does not require an identity.
-* `Monoid` has a superclass `Semigroup`, which provides `(<>)`, and does not require an identity.
 * `Applicative` has a superclass `Apply`, which provides `(<*>)` and does not require an implementation for `pure`.
 
 ## Tuples


### PR DESCRIPTION
In Haskell, Semigroup is a superclass of Monoid since base-4.11.0.0, so this no longer needs to be highlighted as a difference from Haskell.
https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Monoid.html