### PR TITLE
Update the documentation with some upcoming v0.14.0 changes

### DIFF
--- a/guides/FFI-Tips.md
+++ b/guides/FFI-Tips.md
@@ -115,14 +115,14 @@ exports.doSomethingImpl = function(isJust, show, value) {
 
 By moving the `show` reference out to `showSomething` the compiler will pick the right `Show` instance for us at that point, so we don't have to deal with typeclass dictionaries in `showSomethingImpl`.
 
-## Why Doesn't my `Eff` Work When Passed to a Normal JS Function?
+## Why Doesn't my `Effect` Work When Passed to a Normal JS Function?
 
 ["Representing Side Effects"](https://book.purescript.org/chapter10.html#representing-side-effects) in *PureScript by Example*.
 
 In order to avoid prematurely evaluating effects (or evaluating effects that should not be evaluated at all), PureScript wraps them in constant functions:
 
 ```javascript
-exports.myEff = function() {
+exports.myEffect = function() {
   return doSomethingEffectful(1, 2, 3);
 }
 ```
@@ -130,5 +130,5 @@ exports.myEff = function() {
 which is imported to PureScript as:
 
 ```purescript
-foreign import myEff :: forall eff. Eff (myEff :: MYEFF | eff) SomeType
+foreign import myEffect :: Effect SomeType
 ```

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -289,6 +289,7 @@ The PureScript compiler does not support GHC-like language extensions. However, 
 * TypeSynonymInstances
 * RoleAnnotations
 * PolyKinds
+* StandaloneKindSignatures
 
 Note on `DataKinds`: Unlike in Haskell, user-defined kinds are open, and they are not promoted, which means that their constructors can only be used in types, and not in values. For more information about the kind system, see https://github.com/purescript/documentation/blob/master/language/Types.md#kind-system
 

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -288,6 +288,7 @@ The PureScript compiler does not support GHC-like language extensions. However, 
 * ScopedTypeVariables
 * TypeSynonymInstances
 * RoleAnnotations
+* PolyKinds
 
 Note on `DataKinds`: Unlike in Haskell, user-defined kinds are open, and they are not promoted, which means that their constructors can only be used in types, and not in values. For more information about the kind system, see https://github.com/purescript/documentation/blob/master/language/Types.md#kind-system
 

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -287,6 +287,7 @@ The PureScript compiler does not support GHC-like language extensions. However, 
 * RebindableSyntax
 * ScopedTypeVariables
 * TypeSynonymInstances
+* RoleAnnotations
 
 Note on `DataKinds`: Unlike in Haskell, user-defined kinds are open, and they are not promoted, which means that their constructors can only be used in types, and not in values. For more information about the kind system, see https://github.com/purescript/documentation/blob/master/language/Types.md#kind-system
 

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -286,6 +286,7 @@ The PureScript compiler does not support GHC-like language extensions. However, 
 * RankNTypes
 * RebindableSyntax
 * ScopedTypeVariables
+* TypeSynonymInstances
 
 Note on `DataKinds`: Unlike in Haskell, user-defined kinds are open, and they are not promoted, which means that their constructors can only be used in types, and not in values. For more information about the kind system, see https://github.com/purescript/documentation/blob/master/language/Types.md#kind-system
 

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -209,13 +209,13 @@ In the past, PureScript used `return`. However, it is now removed and replaced w
 
 ## Array Comprehensions
 
-PureScript does not provide special syntax for array comprehensions. Instead, use `do`-notation. The `guard` function from the `Control.MonadPlus` module in `purescript-control` can be used to filter results:
+PureScript does not provide special syntax for array comprehensions. Instead, use `do`-notation. The `guard` function from the `Control.Alternative` module in `purescript-control` can be used to filter results:
 
 ```purescript
 import Prelude (($), (*), (==), bind, pure)
 import Data.Array ((..))
 import Data.Tuple (Tuple(..))
-import Control.MonadZero (guard)
+import Control.Alternative (guard)
 
 factors :: Int -> Array (Tuple Int Int)
 factors n = do

--- a/language/FFI.md
+++ b/language/FFI.md
@@ -38,8 +38,8 @@ foreign import document :: {
 }
 ```
 
-When declaring types in this way, you may declare your type to have any kind, not just `Type`. For example, to declare a row of effects:
+When declaring types in this way, you may declare your type to have any kind, not just `Type`. For example, to declare a row of symbols:
 
 ```purescript
-foreign import data MyRow :: # Effect
+foreign import data MyRow :: Row Symbol
 ```

--- a/language/Records.md
+++ b/language/Records.md
@@ -24,9 +24,9 @@ Fields of records can be accessed using a dot, followed by the label of the fiel
 
 `{ ... }` is just syntactic sugar for the `Record` type constructor, so `{ language ::  String }` is the same as `Record ( language :: String )`.
 
-The Record type constructor is parameterized by a row of types. In kind notation, `Record` has kind `# Type -> Type`. That is, it takes a row of types to a type.
+The Record type constructor is parameterized by a row of types. In kind notation, `Record` has kind `Row Type -> Type`. That is, it takes a row of types to a type.
 
-`( language :: String )` denotes a row of types (something of kind `# Type`), so it can be passed to `Record` to construct a type, namely `Record ( language :: String )`.
+`( language :: String )` denotes a row of types (something of kind `Row Type`), so it can be passed to `Record` to construct a type, namely `Record ( language :: String )`.
 
 ## Extending Records
 

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -237,3 +237,4 @@ Other classes
 - [`Partial`](https://pursuit.purescript.org/builtins/docs/Prim#t:Partial)
 - [`Fail`](https://pursuit.purescript.org/builtins/docs/Prim.TypeError#t:Fail)
 - [`Warn`](https://pursuit.purescript.org/builtins/docs/Prim.TypeError#t:Warn)
+- [`Coercible`](https://pursuit.purescript.org/builtins/docs/Prim.Coerce#t:Coercible)

--- a/language/Types.md
+++ b/language/Types.md
@@ -201,12 +201,6 @@ mkDoubledFoo foo bar = { foo: 2.0*foo, bar: 2.0*bar }
 -- (Remember that Bar Number is the same as Foo)
 doubleFoo :: Foo -> Foo
 doubleFoo = combineBar mkDoubledFoo
-
--- Define type synonyms to help write complex Effect rows
--- This will accept further Effects to be added to the row
-type RandomConsoleEffects eff = ( random :: RANDOM, console :: CONSOLE | eff )
--- This limits the Effects to just RANDOM and CONSOLE
-type RandomConsoleEffect = RandomConsoleEffects ()
 ```
 
 ## Constrained Types

--- a/language/Types.md
+++ b/language/Types.md
@@ -209,8 +209,6 @@ type RandomConsoleEffects eff = ( random :: RANDOM, console :: CONSOLE | eff )
 type RandomConsoleEffect = RandomConsoleEffects ()
 ```
 
-Unlike newtypes, type synonyms are merely aliases and cannot be distinguished from usages of their expansion. Because of this they cannot be used to declare a type class instance. For more see [``TypeSynonymInstance`` Error](../errors/TypeSynonymInstance.md#typesynonyminstance-error).
-
 ## Constrained Types
 
 Polymorphic types may be predicated on one or more ``constraints``. See the chapter on type classes for more information.


### PR DESCRIPTION
This pull request takes into account type synonym instances, roles declarations, `Coercible`, the deprecation of the `#` in favor of `Row` and the deprecation of `MonadZero`. I’m not aware of anything else.

I also noticed and removed a few references to `Eff`, the old `Effect` kind and effect rows.