### PR TITLE
Add documentation for escape sequences

### DIFF
--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -52,6 +52,14 @@ ap :: forall m a b. (Monad m) => m (a -> b) -> m a -> m b
 
 There is a native `Number` type which represents JavaScript's standard IEEE 754 float and an `Int` which is restricted to the range of 32-bit integers. In JavaScript, the `Int` values and operations are generated with a `|0` postfix to achieve this, e.g. if you have variables `x`, `y`, and `z` of type `Int`, then the PureScript expression `(x + y) * z` would compile to `((x + y)|0 * z)|0`.
 
+#### Strings
+
+There is a native `String` type which is distinct from `Array Char`. A `String` consists of UTF-16 code units and may contain unpaired surrogates. Working with Unicode code points is supported by library functions. The set of supported escape sequences for string literals is different from both Haskell and JavaScript. 
+
+#### Chars
+
+PureScript has a type `Char` which represents a UTF-16 code unit for compatibility with JavaScript. In contrast, the type `Char` in Haskell represents a Unicode code point.
+
 ### Unit
 
 PureScript has a type `Unit` used in place of Haskell's `()`. The `Prelude` module provides a value `unit` that inhabits this type.

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -147,9 +147,48 @@ String literals are enclosed in double-quotes and may extend over multiple lines
 
 Line breaks will be omitted from the string when written this way.
 
+#### Escape sequences
+
+String literals can contain a variety of escape sequences. The following escape sequences insert a commonly used control character:
+
+``` purescript
+"\t" -- tab (U+0009)
+"\n" -- line feed (U+000A)
+"\r" -- carriage return (U+000D)
+```
+  
+The following escape sequences insert a character which normally has special meaning in string literals:
+
+``` purescript
+"\\" -- backslash
+"\"" -- double-quote
+"\'" -- apostrophe
+```
+
+Hexadecimal escape sequences can be used to insert an arbitrary Unicode code point. They start with `\x` and can contain 1 to 6 hexadecimal digits.
+
+``` purescript
+"\x0"      -- U+0000 (the lowest valid code point) 
+"\x2713"   -- U+2713 (check mark)
+"\x02713"  -- U+2713 as well
+"\x10ffff" -- U+10FFFF (the highest valid code point)
+```
+
+If you want to include a hexadecimal digit after such an escape sequence you have two options. You can break the string into two parts:
+
+``` purescript
+"\x2713" <> "1"
+```
+
+or use leading zeros in the escape sequence to make sure it has six digits:
+
+``` purescript
+"\x0027131"
+```
+
 #### Triple-quote Strings
 
-If line breaks are required in the output, they can be inserted with `\n`. Alternatively, you can use triple double-quotes to prevent special parsing of escaped symbols. This also allows the use of double quotes within the string with no need to escape them:
+You can use triple double-quotes to prevent special parsing of escaped symbols. This also allows the use of double-quotes within the string with no need to escape them:
 
 ``` purescript
 jsIsHello :: String


### PR DESCRIPTION
This pull requests adds a description of valid escape sequences in string literals. I also briefly describes the differences to Haskell regarding string and chars.

I am still new to PureScript. I discovered this information through experiments and by reading the source code of the PureScript compiler. The proposed changes represent what I wished would have been in the documentation when I started with PureScript. Please let me know if the content or style needs changes.

Thanks!