### PR TITLE
Update, remove and add links

### DIFF
--- a/migration-guides/0.14-Migration-Guide.md
+++ b/migration-guides/0.14-Migration-Guide.md
@@ -1,6 +1,6 @@
 # PureScript 0.14 Migration Guide
 
-This guide summarizes the changes you may need to make to your code to migrate from PureScript 0.13 to PureScript 0.14. It covers major changes to the compiler, the core libraries, and tooling. For a detailed review of changes to the compiler in this release, please see the [compiler changelog for PureScript 0.14](https://github.com/purescript/purescript/blob/master/CHANGELOG.md#v0140).
+This guide summarizes the changes you may need to make to your code to migrate from PureScript 0.13 to PureScript 0.14. It covers major changes to the compiler, the core libraries, and tooling. For a detailed review of changes to the compiler in this release, please see the [compiler release notes for PureScript 0.14](https://github.com/purescript/purescript/releases/tag/v0.14.0).
 
 Compiler releases are often accompanied by breaking changes in the core libraries. While some major library changes are described in this document, you should consult the individual changelogs for any libraries you depend on.
 

--- a/migration-guides/0.14-Migration-Guide.md
+++ b/migration-guides/0.14-Migration-Guide.md
@@ -328,7 +328,7 @@ If you are using the `MonadZero m` constraint, replace it with `Monad m` and `Al
 
 If you are _providing_ a `MonadZero` instance, consider removing it, as the class will be removed in a future release.
 
-Note: When you compile core modules that export `MonadZero` instances, such as `Data.List` or `Data.Maybe`, they will yield deprecation warnings until we remove the instances. Those warnings can be hidden by installing `psa` and compiling with `psa --censor-codes=UserDefinedWarning`.
+Note: When you compile core modules that export `MonadZero` instances, such as `Data.List` or `Data.Maybe`, they will yield deprecation warnings until we remove the instances. Those warnings can be hidden by installing [psa](https://github.com/natefaubion/purescript-psa) and compiling with `psa --censor-codes=UserDefinedWarning`.
 
 #### The `Foldable1` class added `foldl1` and `foldr1` as members.
 

--- a/migration-guides/0.14-Migration-Guide.md
+++ b/migration-guides/0.14-Migration-Guide.md
@@ -14,7 +14,7 @@ Compiler releases are often accompanied by breaking changes in the core librarie
 
 The PureScript 0.14 compiler introduces a number of new features, including support for polymorphic kinds and zero-cost coercions. These features may require changes to your code.
 
-This section of the guide will walk through common changes you may need to make, but it isn't a complete overview of changes in the 0.14 compiler and doesn't provide an explanation of these new features. You should also consult the [PureScript 0.14 compiler release notes]().
+This section of the guide will walk through common changes you may need to make, but it isn't a complete overview of changes in the 0.14 compiler and doesn't provide an explanation of these new features.
 
 ### Polykinds & Type :: Type
 


### PR DESCRIPTION
I replaced the link to the changelog with a link to the release notes, removed a sentence that seems redundant to me and added another link to `psa` (there’s already one later in the migration guide but I think it is helpful to have one in the MonadZero section for those not already aware of `psa`).