### PR TITLE
Explicitly install all dependencies in GS guide

### DIFF
--- a/guides/Getting-Started.md
+++ b/guides/Getting-Started.md
@@ -62,7 +62,7 @@ Dependencies can be installed using Spago. We will be using the `lists` and `fol
 
     spago install lists foldable-traversable
 
-The `lists` library sources should now be available in the `.spago/lists/{version}/` subdirectory, and will be included when you compile your project.
+The `lists` and `foldable-traversable` library sources should now be available in the `.spago/lists/{version}/` and `.spago/foldable-traversable/{version}/` subdirectories respectively, and will be included when you compile your project.
 
 ### Working in PSCI
 

--- a/guides/Getting-Started.md
+++ b/guides/Getting-Started.md
@@ -58,9 +58,9 @@ If everything was built successfully, and the tests ran without problems, then t
 
 ### Installing Dependencies
 
-Dependencies can be installed using Spago. We will be using the `lists` library shortly, so install it now:
+Dependencies can be installed using Spago. We will be using the `lists` and `foldable-traversable` libraries shortly, so install those now:
 
-    spago install lists
+    spago install lists foldable-traversable
 
 The `lists` library sources should now be available in the `.spago/lists/{version}/` subdirectory, and will be included when you compile your project.
 


### PR DESCRIPTION
Spago 0.20.0 requires that direct dependencies are explicitly installed. Previously, `foldable-traversable` was installed via `lists` as a transitive dependency.

Fixes #383