### PR TITLE
docs(generic): update genericShow module reference

### DIFF
--- a/guides/Type-Class-Deriving.md
+++ b/guides/Type-Class-Deriving.md
@@ -104,7 +104,7 @@ main = logShow (Score 5)
 
 ```purs
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Effect.Console (logShow)
 
 newtype Score = Score Int
@@ -127,7 +127,7 @@ Be careful when using generic functions with recursive data types. Due to strict
 
 ```purs
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Effect.Console (logShow)
 
 data Chain a


### PR DESCRIPTION
I tried executing the code found in the [Generic](https://github.com/purescript/documentation/blob/master/guides/Type-Class-Deriving.md) section but kept getting an error:

<details>
<summary>Data.Generic.Rep.Show</summary>

```purescript
#+begin_src purescript
import Data.Generic.Rep (class Generic)
-- import Data.Show.Generic (genericShow)
import Data.Generic.Rep.Show (genericShow)
import Effect.Console (logShow)

newtype Score = Score Int

:paste

-- generic deriving prints wrapper with show
derive instance genericScore :: Generic Score _
instance showScore :: Show Score where
  show = genericShow

main = logShow (Score 5)
-- Prints:
-- (Score 5)
#+end_src

#+RESULTS:
#+begin_example
PSCi, version 0.14.0
Type :? for help

import Prelude

> > > Error found:
in module [33m$PSCI[0m
at <internal>:0:0 - 0:0 (line 0, column 0 - line 0, column 0)

  Unknown module [33mData.Generic.Rep.Show[0m


See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
or to contribute content related to this error.


> > > > > … … … … … … … … … … Error found:
in module [33m$PSCI[0m
at :5:10 - 5:21 (line 5, column 10 - line 5, column 21)

  Unknown value [33mgenericShow[0m


See https://github.com/purescript/documentation/blob/master/errors/UnknownName.md for more information,
or to contribute content related to this error.


> See ya!
()
#+end_example
```
</details>

Per [Data.Generic.Rep.Show](https://pursuit.purescript.org/packages/purescript-generics-rep/5.0.0/docs/Data.Generic.Rep.Show) in pursuit, the package is deprecated.

I looked for the `genericShow` function and found it in [Data.Show.Generic](https://pursuit.purescript.org/packages/purescript-prelude/5.0.0/docs/Data.Show.Generic#v:genericShow):

<details>
<summary>Data.Show.Generic</summary>

```purescript
#+begin_src purescript
import Data.Generic.Rep (class Generic)
import Data.Show.Generic (genericShow)
-- import Data.Generic.Rep.Show (genericShow)
import Effect.Console (logShow)

newtype Score = Score Int

:paste

-- generic deriving prints wrapper with show
derive instance genericScore :: Generic Score _
instance showScore :: Show Score where
  show = genericShow

main = logShow (Score 5)
-- Prints:
-- (Score 5)
#+end_src

#+RESULTS:
: PSCi, version 0.14.0
: Type :? for help
: 
: import Prelude
: 
: > > > > > > > > … … … … … … … … … … > See ya!
: ()
```
</details>