### PR TITLE
docs(generic): update Data.Generic.Rep link

### DIFF
--- a/guides/Type-Class-Deriving.md
+++ b/guides/Type-Class-Deriving.md
@@ -23,7 +23,7 @@ nub [Some, Arbitrary 1, Some, Some] == [Some, Arbitrary 1]
 ```
 
 Currently, instances for the following classes can be derived by the compiler:
-- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-prelude/5.0.0/docs/Data.Generic.Rep#t:Generic)
+- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Generic.Rep#t:Generic)
 - [Data.Eq (class Eq)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Eq#t:Eq)
 - [Data.Ord (class Ord)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Ord#t:Ord)
 - [Data.Functor (class Functor)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Functor#t:Functor)
@@ -155,4 +155,3 @@ instance showChain :: Show a => Show (Chain a) where
 ```
 
 This technique of undoing point free notation is known as _eta expansion_.
-

--- a/guides/Type-Class-Deriving.md
+++ b/guides/Type-Class-Deriving.md
@@ -23,7 +23,7 @@ nub [Some, Arbitrary 1, Some, Some] == [Some, Arbitrary 1]
 ```
 
 Currently, instances for the following classes can be derived by the compiler:
-- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-generics-rep/docs/Data.Generic.Rep#t:Generic)
+- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-prelude/5.0.0/docs/Data.Generic.Rep#t:Generic)
 - [Data.Eq (class Eq)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Eq#t:Eq)
 - [Data.Ord (class Ord)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Ord#t:Ord)
 - [Data.Functor (class Functor)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Functor#t:Functor)
@@ -72,7 +72,7 @@ But we _can_ use `genericShow`, which works with _any_ type that has a `Generic`
 
 ```purescript
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
+import Data.Show.Generic (genericShow)
 import Effect.Console (logShow)
 
 derive instance genericMyADT :: Generic MyADT _


### PR DESCRIPTION
Point `Data.Generic.Rep` from the [deprecated link](https://pursuit.purescript.org/packages/purescript-generics-rep/6.1.4/docs/Data.Generic.Rep#t:Generic) to the [new link](https://pursuit.purescript.org/packages/purescript-prelude/5.0.0/docs/Data.Generic.Rep#t:Generic)

Also forgot to change `genericShow` reference from last pull request https://github.com/purescript/documentation/pull/385:

<details>
<summary>genericShow</summary>

```purescript
#+begin_src purescript
import Data.Generic.Rep (class Generic)
import Data.Show.Generic (genericShow)
-- import Data.Generic.Rep.Show (genericShow)
import Effect.Console (logShow)

:paste

data MyADT
  = Some
  | Arbitrary Int
  | Contents Number String

derive instance genericMyADT :: Generic MyADT _

instance showMyADT :: Show MyADT where
  show = genericShow
  
main = logShow [Some, Arbitrary 1, Contents 2.0 "Three"]
#+end_src
</details>

#+RESULTS:
: PSCi, version 0.14.0
: Type :? for help
: 
: import Prelude
: 
: > > > > > > … … … … … … … … … … … … … > See ya!
: ()
```