### PR TITLE
Add closing tag to body in example HTML

### DIFF
--- a/guides/Getting-Started.md
+++ b/guides/Getting-Started.md
@@ -275,7 +275,7 @@ Try creating an `index.html` file with the following contents:
 
   <body>
     <script src="./index.js"></script>
-  <body>
+  </body>
 
 </html>
 ```


### PR DESCRIPTION
Just noticed this slight typo in the getting started docs