### PR TITLE
Note precedence of infix operators created with backticks

### DIFF
--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -451,6 +451,12 @@ Operator sections also work for functions used this way:
 fooBy2 = (_ `foo` 2)
 ```
 
+Infix operators created using backticks are left associative with the highest precedence by default.
+
+``` purescript
+result = 1 `add` 2 * 3 -- == 9
+```
+
 ## Case expressions
 
 The `case` and `of` keywords are used to deconstruct values to create logic based on the value's constructors. You can match on multiple values by delimiting them with `,` in the head and cases.

--- a/language/Syntax.md
+++ b/language/Syntax.md
@@ -451,7 +451,7 @@ Operator sections also work for functions used this way:
 fooBy2 = (_ `foo` 2)
 ```
 
-Infix operators created using backticks are left associative with the highest precedence by default.
+Infix operators created using backticks are left associative with the highest precedence.
 
 ``` purescript
 result = 1 `add` 2 * 3 -- == 9


### PR DESCRIPTION
I initially assumed infix operators created with backticks had the lowest precedence.

I couldn't find any PS documentation about this, but assume we're following the same rules as Haskell.
https://stackoverflow.com/questions/8139066/haskell-infix-function-application-precedence