### PR TITLE
Update Differences-from-Haskell.md

### DIFF
--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -6,7 +6,7 @@ As the evaluation strategy matches JavaScript, interoperability with existing co
 
 Keeping strict evaluation also means there is no need for a runtime system or overly complicated JavaScript output. It should also be possible to write higher performance code when needed, as introducing laziness on top of JavaScript comes with an unavoidable overhead.
 
-## Prelude/base
+## Prelude / base
 
 There is no implicit `Prelude` import in PureScript, the `Prelude` module is just like any other. Also, no libraries are distributed with the compiler at all.
 
@@ -134,14 +134,14 @@ This is so that `=>` can always be read as logical implication; in the above cas
 
 ### Named instances
 
-In PureScript, instances must be given names:
+In PureScript, you can give names to instances:
 
 ```purescript
 instance arbitraryUnit :: Arbitrary Unit where
   ...
 ```
 
-Overlapping instances are still disallowed, like in Haskell. The instance names are used to help the readability of compiled JavaScript.
+Although instance names are optional, they can help the readability of compiled JavaScript. Overlapping instances are still disallowed, like in Haskell.
 
 ### Deriving
 
@@ -198,7 +198,7 @@ In PureScript, number literals are not overloaded as in Haskell. That is, `1` is
 
 PureScript has no special syntax for tuples as records can fulfill the same role that *n*-tuples do with the advantage of having more meaningful types and accessors.
 
-A `Tuple` type for 2-tuples is available via the [purescript-tuples](https://github.com/purescript/purescript-tuples) library. `Tuple` is treated the same as any other type or data constructor.
+A `Tuple` type for 2-tuples is available via the [purescript-tuples](https://github.com/purescript/purescript-tuples) library. `Tuple` is treated the same as any other type or data constructor. There is a shorthand `a /\ b` for `Tuple a b` in [Data.Tuple.Nested](https://pursuit.purescript.org/packages/purescript-tuples/6.0.1/docs/Data.Tuple.Nested).
 
 ## Composition operator
 


### PR DESCRIPTION
The commit includes two changes to `Differences-from-Haskell.md`:
- Updated the description of named instances in favor of [PureScript 0.14.2](https://github.com/purescript/purescript/releases/tag/v0.14.2);
- Added some words about the shorthand operator `/\` for `Tuple`.