### PR TITLE
Type classes: Omit explicit instance name

### DIFF
--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -153,8 +153,8 @@ data MyADT
   | Arbitrary Int
   | Contents Number String
 
-derive instance eqMyADT :: Eq MyADT
-derive instance ordMyADT :: Ord MyADT
+derive instance Eq MyADT
+derive instance Ord MyADT
 
 nub [Some, Arbitrary 1, Some, Some] == [Some, Arbitrary 1]
 ```
@@ -195,8 +195,8 @@ instance semiringScore :: Semiring Score where
 Note that we can use either of these options to derive an `Eq` instance for a `newtype`, since `Eq` has built-in compiler support. They are equivalent in this case.
 
 ```purs
-derive instance eqScore :: Eq Score
-derive newtype instance eqScore :: Eq Score
+derive instance Eq Score
+derive newtype instance Eq Score
 ```
 
 ### Deriving from `Generic`


### PR DESCRIPTION
The compiler change to make instance names optional was introduced in v0.14.2:
https://github.com/purescript/purescript/releases/tag/v0.14.2