### PR TITLE
replace ref to deprecated generics-rep

### DIFF
--- a/guides/Type-Class-Deriving.md
+++ b/guides/Type-Class-Deriving.md
@@ -23,7 +23,7 @@ nub [Some, Arbitrary 1, Some, Some] == [Some, Arbitrary 1]
 ```
 
 Currently, instances for the following classes can be derived by the compiler:
-- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Generic.Rep#t:Generic)
+- Data.Generic.Rep (class Generic) [see below](../guides/Type-Class-Deriving.md#deriving-from-generic)
 - [Data.Eq (class Eq)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Eq#t:Eq)
 - [Data.Ord (class Ord)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Ord#t:Ord)
 - [Data.Functor (class Functor)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Functor#t:Functor)
@@ -119,7 +119,7 @@ main = logShow (Score 5)
 -- (Score 5)
 ```
 
-More information on Generic deriving is available [in the generics-rep library documentation](https://pursuit.purescript.org/packages/purescript-generics-rep). See this [blog post](https://harry.garrood.me/blog/write-your-own-generics/) for a tutorial on how to write your own `generic` functions.
+You can try out generic deriving in the example at [Try PureScript](https://try.purescript.org/). See also [Jordan's Reference](https://jordanmartinez.github.io/purescript-jordans-reference-site/content/31-Design-Patterns/22-Generics.html) for more discussion, and this [blog post](https://harry.garrood.me/blog/write-your-own-generics/) for a tutorial on how to write your own `generic` functions (NB there have been language and library changes since that post).
 
 #### Avoiding stack overflow errors with recursive types
 

--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -166,13 +166,7 @@ and `Ord`.  See
 [here](https://github.com/purescript/documentation/blob/master/language/Type-Classes.md#type-class-deriving)
 for a list of other type classes.
 
-Using generics, it is also possible to use generic implementations for type
-classes like `Bounded`, `Monoid`, and `Show`.  See
-[the generics-rep library](https://pursuit.purescript.org/packages/purescript-generics-rep)
-for a list of other type classes that have generic implementations, as well as
-an explanation of how to write generic implementations for your own type
-classes.
-
+Furthermore, using generics, it is also possible to use generic implementations for type classes like `Bounded`, `Monoid`, and `Show`. See the [deriving guide](../guides/Type-Class-Deriving.md#deriving-from-generic) for more information.
 ### Orphan Instances
 
 Unlike Haskell, orphan instances are completely disallowed in PureScript.  It is a compiler error to try to declare orphan instances.

--- a/language/Type-Classes.md
+++ b/language/Type-Classes.md
@@ -160,7 +160,7 @@ nub [Some, Arbitrary 1, Some, Some] == [Some, Arbitrary 1]
 ```
 
 Currently, instances for the following classes can be derived by the compiler:
-- [Data.Generic.Rep (class Generic)](https://pursuit.purescript.org/packages/purescript-generics-rep/docs/Data.Generic.Rep#t:Generic)
+- Data.Generic.Rep (class Generic) 
 - [Data.Eq (class Eq)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Eq#t:Eq)
 - [Data.Ord (class Ord)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Ord#t:Ord)
 - [Data.Functor (class Functor)](https://pursuit.purescript.org/packages/purescript-prelude/docs/Data.Functor#t:Functor)


### PR DESCRIPTION
What's in this PR:

changes to (1) "Differences from Haskell" page and (2) Guide page on "Type Class Deriving"  and (3) the "Language: Type Classes" page, that had outdated references to the deprecated `purescript-generics-rep` repo,

Since there is a good example in the Try PureScript examples, i added a link to that (link is to Try PureScript! itself, i don't think you can link to a specific example because of the structure of the link, will correct if i'm wrong on that) 