### PR TITLE
Remove old reminder for arc section

### DIFF
--- a/migration-guides/0.15-Migration-Guide.md
+++ b/migration-guides/0.15-Migration-Guide.md
@@ -680,8 +680,6 @@ An arc could only be drawn clockwise due to an options field not being exposed i
 - To just migrate code, set `useCounterClockwise` to false
 - To get the new counter-clockwise behavior , set `useCounterClockwise` to true
 
-- Support arcs that are drawn counter-clockwise (#58, #83 by @karljs and @JordanMartinez)
-
 ### `Transform` record type's fields renamed (`purescript-canvas`)
 
 The `Transform` field names were changed because the values referenced by `m31` and `m32` corresponded to `dX` and `dY` in other contexts. MDN docs would use fields `a-f` to refer to the values in a context-agnostic way.


### PR DESCRIPTION
Per https://github.com/purescript/documentation/pull/431#issuecomment-1087832573, I checked to see whether there were any PRs that backlink to this repo rather than the correct repo. The only ones that didn't were on a line that should have been removed.