### PR TITLE
Regenerate ecosystem changelog for 0.15.0 ecosystem guide

### DIFF
--- a/migration-guides/0.15-Ecosystem-Update.md
+++ b/migration-guides/0.15-Ecosystem-Update.md
@@ -12,7 +12,7 @@ If a library's changes consisted only of the above entries, it was removed from 
 
 ## `purescript` Libraries
 
-### purescript-arrays
+### `arrays`
 
 Breaking changes:
 - Drop deprecated `group'` and `empty` ([#219](https://github.com/purescript/purescript-arrays/pull/219) by @JordanMartinez)
@@ -20,17 +20,17 @@ Breaking changes:
 Other improvements:
 - Fixed minor documentation issue with `find` ([#216](https://github.com/purescript/purescript-arrays/pull/216) by @JamieBallingall)
 
-### purescript-console
+### `console`
 
 New features:
 - Added `debug` ([#36](https://github.com/purescript/purescript-console/pull/36))
 
-### purescript-control
+### `control`
 
 Breaking changes:
 - Make `<|>` right associative ([#80](https://github.com/purescript/purescript-control/pull/80) by @JordanMartinez)
 
-### purescript-foldable-traversable
+### `foldable-traversable`
 
 Breaking changes:
 - Drop deprecated `foldMap1Default` ([#147](https://github.com/purescript/purescript-foldable-traversable/pull/147) by @JordanMartinez)
@@ -38,7 +38,7 @@ Breaking changes:
 Other improvements:
 - Narrow down unnecessarily imprecise type of `mapWithIndexArray` ([#145](https://github.com/purescript/purescript-foldable-traversable/pull/145))
 
-### purescript-foreign
+### `foreign`
 
 Other improvements:
 - Replace all usages of `F` and `FT` with `Except`/`ExceptT (NonEmptyList ForeignError)` ([#87](https://github.com/purescript/purescript-foreign/pull/87) by @JordanMartinez)
@@ -47,17 +47,17 @@ Other improvements:
   haven't been deprecated, but usage of them is now discouraged. All code in the library now uses
   the full type that is aliased by `F` and `FT`.
 
-### purescript-free
+### `free`
 
 Breaking changes:
 - Drop deprecated `unfoldCofree`; use `buildCofree` instead ([#124](https://github.com/purescript/purescript-free/pull/124) by @JordanMartinez)
 
-### purescript-graphs
+### `graphs`
 
 New features:
 - Added `Foldable` and `Traversable` instances for `Graph` ([#16](https://github.com/purescript/purescript-graphs/pull/16) by @MaybeJustJames)
 
-### purescript-integers
+### `integers`
 
 Breaking changes:
 - Migrate `trunc` from `math` package ([#51](https://github.com/purescript/purescript-integers/pull/51) by @JordanMartinez)
@@ -65,28 +65,28 @@ Breaking changes:
 Other improvements:
 - Drop dependency on deprecated `math` package ([#51](https://github.com/purescript/purescript-integers/pull/51) by @JordanMartinez)
 
-### purescript-lists
+### `lists`
 
 Breaking changes:
 - Drop deprecated `group'` and `mapWithIndex` ([#206](https://github.com/purescript/purescript-lists/pull/206) by @JordanMartinez)
 - Change `groupAllBy` to use a comparison function ([#191](https://github.com/purescript/purescript-lists/pull/191))
 
-### purescript-maybe
+### `maybe`
 
 New features:
 - Added `Semiring` instance ([#59](https://github.com/purescript/purescript-maybe/pull/59))
 
-### purescript-newtype
+### `newtype`
 
 New features:
 - Added `modify` ([#19](https://github.com/purescript/purescript-newtype/pull/19) by @dwhitney)
 
-### purescript-nonempty
+### `nonempty`
 
 Other improvements:
 - Drop deprecation warning on `fold1` ([#45](https://github.com/purescript/purescript-nonempty/pull/45) by @JordanMartinez)
 
-### purescript-numbers
+### `numbers`
 
 New features:
 - Ported various functions & constants from `purescript-math` ([#18](https://github.com/purescript/purescript-numbers/pull/18) by @JamieBallingall)
@@ -101,7 +101,7 @@ New features:
   - Numeric constants: `e`, `ln2`, `ln10`, `log10e`, `log2e`, `pi`, `sqrt1_2`,
   `sqrt2`, and `tau`
 
-### purescript-ordered-collections
+### `ordered-collections`
 
 New features:
 - Exported `Data.Map.Internal` data constructors ([#52](https://github.com/purescript/purescript-ordered-collections/pull/52) by @natefaubion)
@@ -110,11 +110,11 @@ New features:
 Performance improvements:
 - Improved speed of `foldr`, `foldl`, `foldMap`, `foldlWithIndex`, `foldrWithIndex`, `foldMapWithIndex`, `unionWith`, `keys` and `values` ([#60](https://github.com/purescript/purescript-ordered-collections/pull/60) by @xgrommx, [#61](https://github.com/purescript/purescript-ordered-collections/pull/61) and [#62](https://github.com/purescript/purescript-ordered-collections/pull/62) by @JordanMartinez)
 
-### purescript-prelude
+### `prelude`
 
 Breaking changes:
 - Change Generic Rep's `NoConstructors` to newtype `Void` ([#282](https://github.com/purescript/purescript-prelude/pull/282) by @JordanMartinez)
-- Replaced polymorphic proxies with monomorphic `Proxy` ([#281](https://github.com/purescript/purescript-prelude/pull/281), #288 by @JordanMartinez)
+- Replaced polymorphic proxies with monomorphic `Proxy` ([#281](https://github.com/purescript/purescript-prelude/pull/281), [#288](https://github.com/purescript/purescript-prelude/pull/288) by @JordanMartinez)
 - Fix `signum zero` to return `zero` ([#280](https://github.com/purescript/purescript-prelude/pull/280) by @JordanMartinez)
 - Fix `Show` instance on records with duplicate labels by adding `Nub` constraint ([#269](https://github.com/purescript/purescript-prelude/pull/269) by @JordanMartinez)
 
@@ -129,7 +129,7 @@ Other improvements:
 - The internal FFI function `join` in `Data.Show` has been renamed to `intercalate` to
   match the same function in `Data.Show.Generic` ([#274](https://github.com/purescript/purescript-prelude/pull/274) by @cdepillabout)
 
-### purescript-quickcheck
+### `quickcheck`
 
 Breaking changes:
 - Replaced polymorphic proxies with monomorphic `Proxy` ([#132](https://github.com/purescript/purescript-quickcheck/pull/132) by @JordanMartinez)
@@ -140,12 +140,12 @@ Breaking changes:
 Bugfixes:
 - `quickCheckPure` and `quickCheckPure'` stack safety ([#127](https://github.com/purescript/purescript-quickcheck/pull/127))
 
-### purescript-record
+### `record`
 
 Breaking changes:
 - Replaced polymorphic proxies with monomorphic `Proxy` ([#81](https://github.com/purescript/purescript-record/pull/81) by @JordanMartinez)
 
-### purescript-strings
+### `strings`
 
 Breaking changes:
 - Replaced polymorphic proxies with monomorphic `Proxy` ([#158](https://github.com/purescript/purescript-strings/pull/158) by @JordanMartinez)
@@ -153,13 +153,14 @@ Breaking changes:
 
 Other improvements:
 - Surround code with backticks in documentation ([#148](https://github.com/purescript/purescript-strings/pull/148))
+- Make `RegexFlags` a `newtype` and a `Newtype` instance for it([#159](https://github.com/purescript/purescript-strings/pull/159) by @mhmdanas)
 
-### purescript-transformers
+### `transformers`
 
 New features:
 - Add `Foldable`, `FoldableWithIndex`, and `Traversable` instances for `EnvT` ([#113](https://github.com/purescript/purescript-transformers/pull/113) by @abaco)
 
-### purescript-typelevel-prelude
+### `typelevel-prelude`
 
 Breaking changes:
 - Replaced polymorphic proxies with monomorphic `Proxy` ([#72](https://github.com/purescript/purescript-typelevel-prelude/pull/72) by @JordanMartinez)
@@ -167,30 +168,30 @@ Breaking changes:
 New features:
 - Added `#` infix operator for `FLIP` (e.g. `Int # Maybe` == `Maybe Int`) ([#73](https://github.com/purescript/purescript-typelevel-prelude/pull/73) by @JordanMartinez)
 
-### purescript-unfoldable
+### `unfoldable`
 
 New features:
 - Add `iterateN` function ([#20](https://github.com/purescript/purescript-unfoldable/pull/20) by @matthewleon and @JordanMartinez)
 
-### purescript-validation
+### `validation`
 
 Breaking changes:
 - Drop deprecated `unV`; use `validation` instead ([#38](https://github.com/purescript/purescript-validation/pull/38) by @JordanMartinez)
 
 ## `purescript-contrib` Libraries
 
-### purescript-aff
+### `aff`
 
 Breaking changes:
-- Restrict the signature of `launchAff_` to only work on `Aff Unit` ([#203](https://github.com/contrib/purescript-aff/pull/203) by @i-am-the-slime)
+- Restrict the signature of `launchAff_` to only work on `Aff Unit` ([#203](https://github.com/purescript-contrib/purescript-aff/pull/203) by @i-am-the-slime)
 
 Other improvements:
-- Ensure all directly-imported packages are included in the `spago.dhall` file ([#205](https://github.com/contrib/purescript-aff/pull/205) by @ptrfrncsmrph)
+- Ensure all directly-imported packages are included in the `spago.dhall` file ([#205](https://github.com/purescript-contrib/purescript-aff/pull/205) by @ptrfrncsmrph)
 
-### purescript-affjax
+### `affjax`
 
 Breaking changes:
-- Update all request functions to take a driver arg ([#171](https://github.com/contrib/purescript-affjax/pull/171) by @JordanMartinez)
+- Update all request functions to take a driver arg ([#171](https://github.com/purescript-contrib/purescript-affjax/pull/171) by @JordanMartinez)
 
   Affjax works on the Node.js and browser environments by relying on a `require`
   statement within a function. Depending on the environment detected,
@@ -208,67 +209,67 @@ Breaking changes:
   - If on Node.js, use [`purescript-affjax-node`](https://github.com/purescript-contrib/purescript-affjax-node/).
   - If on the brower, use [`purescript-affjax-web`](https://github.com/purescript-contrib/purescript-affjax-web/).
 
-### purescript-affjax-node
+### `affjax-node`
 
 New library for making `purescript-affjax` work on Node
 
-### purescript-affjax-web
+### `affjax-web`
 
 New library for making `purescript-affjax` work on the browser
 
-### purescript-argonaut-core
+### `argonaut-core`
 
 Other improvements:
-* Fixed readme bug where `jsonParser` was imported from `Data.Argonaut.Core` instead of `Data.Argonaut.Parser` ([#50](https://github.com/contrib/purescript-argonaut-core/pull/50) by @flip111)
+* Fixed readme bug where `jsonParser` was imported from `Data.Argonaut.Core` instead of `Data.Argonaut.Parser` ([#50](https://github.com/purescript-contrib/purescript-argonaut-core/pull/50) by @flip111)
 
-### purescript-argonaut-traversals
+### `argonaut-traversals`
 
 Other improvements:
-- Updated `README.md` to make the Quick start example runnable ([#37](https://github.com/contrib/purescript-argonaut-traversals/pull/37) by @dk949)
+- Updated `README.md` to make the Quick start example runnable ([#37](https://github.com/purescript-contrib/purescript-argonaut-traversals/pull/37) by @dk949)
 
-### purescript-arraybuffer
+### `arraybuffer`
 
 Breaking Changes:
-- Replaced polymorphic proxies with monomorphic `Proxy` ([#41](https://github.com/contrib/purescript-arraybuffer/pull/41) by @JordanMartinez)
+- Replaced polymorphic proxies with monomorphic `Proxy` ([#41](https://github.com/purescript-contrib/purescript-arraybuffer/pull/41) by @JordanMartinez)
 
-### purescript-colors
+### `colors`
 
 New features:
-- Support for alpha channel added to `toHexString` and `fromHexString` ([#56](https://github.com/contrib/purescript-colors/pull/56) by @nsaunders)
+- Support for alpha channel added to `toHexString` and `fromHexString` ([#56](https://github.com/purescript-contrib/purescript-colors/pull/56) by @nsaunders)
 
-### purescript-css
+### `css`
 
 Breaking changes:
-- Add support for `calc` expressions ([#140](https://github.com/contrib/purescript-css/pull/140) by @nsaunders)
-- Add table selector ([#141](https://github.com/contrib/purescript-css/pull/141) by @plurip-software)
-- Update the box-shadow implementation ([#88](https://github.com/contrib/purescript-css/pull/88) by @vyorkin)
-- Dropped almost all named colors ([#156](https://github.com/contrib/purescript-css/pull/156) by @JordanMartinez)
+- Add support for `calc` expressions ([#140](https://github.com/purescript-contrib/purescript-css/pull/140) by @nsaunders)
+- Add table selector ([#141](https://github.com/purescript-contrib/purescript-css/pull/141) by @plurip-software)
+- Update the box-shadow implementation ([#88](https://github.com/purescript-contrib/purescript-css/pull/88) by @vyorkin)
+- Dropped almost all named colors ([#156](https://github.com/purescript-contrib/purescript-css/pull/156) by @JordanMartinez)
 
   These colors were originally defined in `purescript-colors` (i.e.
   one module per schema) because each schema should be defined as its
   own library. This change was propagated to this release.
 
 New features:
-- Add smart constructors for generic font families ([#68](https://github.com/contrib/purescript-css/pull/68), #136 by @Unisay and @JordanMartinez)
-- Add support for `text-direction` ([#83](https://github.com/contrib/purescript-css/pull/83), #137 by @vyorkin and @JordanMartinez)
-- Add outline and constituent properties ([#145](https://github.com/contrib/purescript-css/pull/145) by @nsaunders)
-- Add support for `visibility` property ([#148](https://github.com/contrib/purescript-css/pull/148) by @nsaunders)
+- Add smart constructors for generic font families ([#68](https://github.com/purescript-contrib/purescript-css/pull/68), [#136](https://github.com/purescript-contrib/purescript-css/pull/136) by @Unisay and @JordanMartinez)
+- Add support for `text-direction` ([#83](https://github.com/purescript-contrib/purescript-css/pull/83), [#137](https://github.com/purescript-contrib/purescript-css/pull/137) by @vyorkin and @JordanMartinez)
+- Add outline and constituent properties ([#145](https://github.com/purescript-contrib/purescript-css/pull/145) by @nsaunders)
+- Add support for `visibility` property ([#148](https://github.com/purescript-contrib/purescript-css/pull/148) by @nsaunders)
 
 Other improvements:
-- Remove ending space in css output (e.g. `padding: 1 2 3 4 `) ([#135](https://github.com/contrib/purescript-css/pull/135) by @chexxor and @JordanMartinez)
+- Remove ending space in css output (e.g. `padding: 1 2 3 4 `) ([#135](https://github.com/purescript-contrib/purescript-css/pull/135) by @chexxor and @JordanMartinez)
 
-### purescript-fork
-
-Other improvements:
-- Ensure all imported packages are in the spago.dhall file ([#17](https://github.com/contrib/purescript-fork/pull/17) by @artemisSystem)
-
-### purescript-now
+### `fork`
 
 Other improvements:
-- Added tests ([#20](https://github.com/contrib/purescript-now/pull/20) by @ntwilson)
-- Added quick start ([#22](https://github.com/contrib/purescript-now/pull/22) by @maxdeviant)
+- Ensure all imported packages are in the spago.dhall file ([#17](https://github.com/purescript-contrib/purescript-fork/pull/17) by @artemisSystem)
 
-### purescript-parsing
+### `now`
+
+Other improvements:
+- Added tests ([#20](https://github.com/purescript-contrib/purescript-now/pull/20) by @ntwilson)
+- Added quick start ([#22](https://github.com/purescript-contrib/purescript-now/pull/22) by @maxdeviant)
+
+### `parsing`
 
 Breaking changes:
 - New optimized internals. `ParserT` now has a more efficient representation,
@@ -282,137 +283,154 @@ Breaking changes:
   Code that constructs parsers via the underlying representation will need to be updated,
   but otherwise the interface is unchanged and parsers should just enjoy the speed boost.
 
-  ([#154](https://github.com/contrib/purescript-parsing/pull/154) by @natefaubion)
-- Make `<??>` right-associative ([#164](https://github.com/contrib/purescript-parsing/pull/164) by @JordanMartinez)
-- Drop `<?>` and `<~?>` prec from 3 to 4 ([#163](https://github.com/contrib/purescript-parsing/pull/163), #164 by @JordanMartinez)
+  ([#154](https://github.com/purescript-contrib/purescript-parsing/pull/154) by @natefaubion)
+- Make `<??>` right-associative ([#164](https://github.com/purescript-contrib/purescript-parsing/pull/164) by @JordanMartinez)
+- Drop `<?>` and `<~?>` prec from 3 to 4 ([#163](https://github.com/purescript-contrib/purescript-parsing/pull/163), [#164](https://github.com/purescript-contrib/purescript-parsing/pull/164) by @JordanMartinez)
 
   `<|>` was made right associative. Decreasing these two operators
   prevents a compiler error (i.e. `MixedAssociativityError`)
   without causing issues with `<$>`.
-- Rename module prefix from `Text.Parsing.Parser` to `Parsing` ([#169](https://github.com/contrib/purescript-parsing/pull/169) by @jamesdbrock)
+- Rename module prefix from `Text.Parsing.Parser` to `Parsing` ([#169](https://github.com/purescript-contrib/purescript-parsing/pull/169) by @jamesdbrock)
+- Replace the `regex` parser. ([#170](https://github.com/purescript-contrib/purescript-parsing/pull/170) by @jamesdbrock)
+- Reorganize Combinators for [#154](https://github.com/purescript-contrib/purescript-parsing/pull/154) ([#182](https://github.com/purescript-contrib/purescript-parsing/pull/182) by @jamesdbrock)
+- Add the `index` field to `Position`. ([#171](https://github.com/purescript-contrib/purescript-parsing/pull/171) by @jamesdbrock)
+- Move the parsers
+  * `whiteSpace`
+  * `skipSpaces`
+  * `oneOf`
+  * `oneOfCodePoints`
+  * `noneOf`
+  * `noneOfCodePoints`
+  from `Parsing.String` to `Parsing.String.Basic`. ([#183](https://github.com/purescript-contrib/purescript-parsing/pull/183) by @jamesdbrock)
+- Change MonadState instance ([#187](https://github.com/purescript-contrib/purescript-parsing/pull/187) by jamesdbrock)
 
-### purescript-profunctor-lenses
+  Users who stack a `ParserT` on a `StateT` base monad will call the `MonadState` members directly like `get` instead of needing to do `lift <<< get`.
+
+  To get the `ParserT` internal state, call `getParserT` instead of `get`.
+
+- Add the `anyTill` primitive `String` combinator. ([#186](https://github.com/purescript-contrib/purescript-parsing/pull/186) by @jamesdbrock)
+
+### `profunctor-lenses`
 
 Breaking changes:
-- Replaced polymorphic proxies with monomorphic `Proxy` ([#141](https://github.com/contrib/purescript-profunctor-lenses/pull/141) by @JordanMartinez)
+- Replaced polymorphic proxies with monomorphic `Proxy` ([#141](https://github.com/purescript-contrib/purescript-profunctor-lenses/pull/141) by @JordanMartinez)
 
 New features:
-- Add `coerced` ([#140](https://github.com/contrib/purescript-profunctor-lenses/pull/140) by @ozkutuk)
-- Add `sans` and `both` ([#97](https://github.com/contrib/purescript-profunctor-lenses/pull/97) by @xgrommx)
+- Add `coerced` ([#140](https://github.com/purescript-contrib/purescript-profunctor-lenses/pull/140) by @ozkutuk)
+- Add `sans` and `both` ([#97](https://github.com/purescript-contrib/purescript-profunctor-lenses/pull/97) by @xgrommx)
 
 Bugfixes:
-- Fix broken `reindex` for v0.15 due to [Purescript PR [#4033](https://github.com/contrib/purescript-profunctor-lenses/pull/4033)](https://github.com/purescript/purescript/pull/4033)
+- Fix broken `reindex` for v0.15 due to [Purescript PR [#4033](https://github.com/purescript-contrib/purescript-profunctor-lenses/pull/4033)](https://github.com/purescript/purescript/pull/4033)
 
 Other improvements:
-- Replace manual tests with automated tests using `assert` ([#135](https://github.com/contrib/purescript-profunctor-lenses/pull/135) by @neppord)
-- Improve documentation for `united` ([#134](https://github.com/contrib/purescript-profunctor-lenses/pull/134) by @neppord)
-- Add guide on impredicativity explaining difference between `Lens` vs `ALens` ([#136](https://github.com/contrib/purescript-profunctor-lenses/pull/136) by @i-am-tom and @JordanMartinez)
+- Replace manual tests with automated tests using `assert` ([#135](https://github.com/purescript-contrib/purescript-profunctor-lenses/pull/135) by @neppord)
+- Improve documentation for `united` ([#134](https://github.com/purescript-contrib/purescript-profunctor-lenses/pull/134) by @neppord)
+- Add guide on impredicativity explaining difference between `Lens` vs `ALens` ([#136](https://github.com/purescript-contrib/purescript-profunctor-lenses/pull/136) by @i-am-tom and @JordanMartinez)
 
-### purescript-quickcheck-laws
+### `quickcheck-laws`
 
 Breaking changes:
-- Drop `Proxy2`/`Proxy3` usage in favor of just `Proxy` ([#59](https://github.com/contrib/purescript-quickcheck-laws/pull/59) by @JordanMartinez)
+- Drop `Proxy2`/`Proxy3` usage in favor of just `Proxy` ([#59](https://github.com/purescript-contrib/purescript-quickcheck-laws/pull/59) by @JordanMartinez)
 
 New features:
-- Provide `Arbitrary`-less law checks ([#36](https://github.com/contrib/purescript-quickcheck-laws/pull/36) by @matthewleon, #57 by @JordanMartinez)
+- Provide `Arbitrary`-less law checks ([#36](https://github.com/purescript-contrib/purescript-quickcheck-laws/pull/36) by @matthewleon, [#57](https://github.com/purescript-contrib/purescript-quickcheck-laws/pull/57) by @JordanMartinez)
 
 Other improvements:
-- Fix integer overflow error in test for Ints ([#58](https://github.com/contrib/purescript-quickcheck-laws/pull/58) by @JordanMartinez)
+- Fix integer overflow error in test for Ints ([#58](https://github.com/purescript-contrib/purescript-quickcheck-laws/pull/58) by @JordanMartinez)
 
-### purescript-react
+### `react`
 
 Breaking changes:
-- Replaced polymorphic proxies with monomorphic `Proxy` ([#185](https://github.com/contrib/purescript-react/pull/185) by @JordanMartinez)
+- Replaced polymorphic proxies with monomorphic `Proxy` ([#185](https://github.com/purescript-contrib/purescript-react/pull/185) by @JordanMartinez)
 
-### purescript-routing
+### `routing`
 
 Other improvements:
-- Update readme to show how to use newtypes ([#57](https://github.com/contrib/purescript-routing/pull/57) by @brodeuralexis and @JordanMartinez)
+- Update readme to show how to use newtypes ([#57](https://github.com/purescript-contrib/purescript-routing/pull/57) by @brodeuralexis and @JordanMartinez)
 
-### purescript-string-parsers
-
-Breaking changes:
-- Change precedence of `withError` operator to accommodate associativity changes in `Control.Alt` ([#92](https://github.com/contrib/purescript-string-parsers/pull/92) by @thomashoneyman)
-
-### purescript-these
+### `string-parsers`
 
 Breaking changes:
-- Replaced polymorphic proxies with monomorphic `Proxy` ([#41](https://github.com/contrib/purescript-these/pull/41) by @JordanMartinez)
+- Change precedence of `withError` operator to accommodate associativity changes in `Control.Alt` ([#92](https://github.com/purescript-contrib/purescript-string-parsers/pull/92) by @thomashoneyman)
 
-### purescript-uri
+### `these`
+
+Breaking changes:
+- Replaced polymorphic proxies with monomorphic `Proxy` ([#41](https://github.com/purescript-contrib/purescript-these/pull/41) by @JordanMartinez)
+
+### `uri`
 
 Bugfixes:
-- Made all parsers stack safe on long input ([#63](https://github.com/contrib/purescript-uri/pull/63) by @garyb)
-- Exceptions are no longer thrown when using e.g. `valueFromString` with lone surrogates ([#68](https://github.com/contrib/purescript-uri/pull/68) by @ysangkok)
+- Made all parsers stack safe on long input ([#63](https://github.com/purescript-contrib/purescript-uri/pull/63) by @garyb)
+- Exceptions are no longer thrown when using e.g. `valueFromString` with lone surrogates ([#68](https://github.com/purescript-contrib/purescript-uri/pull/68) by @ysangkok)
 
 Other improvements:
-- Update README.md rfc link ([#67](https://github.com/contrib/purescript-uri/pull/67) @codingedgar)
+- Update README.md rfc link ([#67](https://github.com/purescript-contrib/purescript-uri/pull/67) @codingedgar)
 
 ## `purescript-web` Libraries
 
-### purescript-canvas
+### `canvas`
 
 Breaking changes:
-- Support arcs that are drawn counter-clockwise ([#58](https://github.com/web/purescript-canvas/pull/58), #83 by @karljs and @JordanMartinez)
-- The `Transform` type now uses the field names `a`, `b`, `c`, `d`, `e` and `f`, instead of `m11`, `m12`, `m21`, `m22`, `m31` and `m32` ([#86](https://github.com/web/purescript-canvas/pull/86) by @artemisSystem)
+- Support arcs that are drawn counter-clockwise ([#58](https://github.com/purescript-web/purescript-canvas/pull/58), [#83](https://github.com/purescript-web/purescript-canvas/pull/83) by @karljs and @JordanMartinez)
+- The `Transform` type now uses the field names `a`, `b`, `c`, `d`, `e` and `f`, instead of `m11`, `m12`, `m21`, `m22`, `m31` and `m32` ([#86](https://github.com/purescript-web/purescript-canvas/pull/86) by @artemisSystem)
 
 New features:
-- Added `createImageDataWith` ([#81](https://github.com/web/purescript-canvas/pull/81))
+- Added `createImageDataWith` ([#81](https://github.com/purescript-web/purescript-canvas/pull/81))
 
 Other improvements:
-- Added ESLint config and fixed the resulting linter issues ([#82](https://github.com/web/purescript-canvas/pull/82))
+- Added ESLint config and fixed the resulting linter issues ([#82](https://github.com/purescript-web/purescript-canvas/pull/82))
 
-### purescript-web-cssom
+### `web-cssom`
 
 Breaking changes:
-- Update `CSSStyleDeclaration` functions to take `style` arg last ([#12](https://github.com/web/purescript-web-cssom/pull/12) by @theqp)
+- Update `CSSStyleDeclaration` functions to take `style` arg last ([#12](https://github.com/purescript-web/purescript-web-cssom/pull/12) by @theqp)
 
   This follows the convention of "the thing being operated on" occurs
   last in function that take multiple arguments.
 
-### purescript-web-dom
+### `web-dom`
 
 Breaking changes:
-- Unwrap returned `Effect` for `doctype` ([#52](https://github.com/web/purescript-web-dom/pull/52) by @JordanMartinez)
-- Port `getBoundingClientRect` from `web-html`; set arg to `Element` ([#53](https://github.com/web/purescript-web-dom/pull/53) by @JordanMartinez)
+- Unwrap returned `Effect` for `doctype` ([#52](https://github.com/purescript-web/purescript-web-dom/pull/52) by @JordanMartinez)
+- Port `getBoundingClientRect` from `web-html`; set arg to `Element` ([#53](https://github.com/purescript-web/purescript-web-dom/pull/53) by @JordanMartinez)
 
-### purescript-web-events
+### `web-events`
 
 New features:
-- Add FFI for `CustomEvent` constructor ([#25](https://github.com/web/purescript-web-events/pull/25) by @JordanMartinez)
-- Add `addEventListenerWithOptions` to expose more options ([#25](https://github.com/web/purescript-web-events/pull/25) by @JordanMartinez)
+- Add FFI for `CustomEvent` constructor ([#25](https://github.com/purescript-web/purescript-web-events/pull/25) by @JordanMartinez)
+- Add `addEventListenerWithOptions` to expose more options ([#25](https://github.com/purescript-web/purescript-web-events/pull/25) by @JordanMartinez)
 
-### purescript-web-file
+### `web-file`
 
 Other improvements:
-- Update `Math` import to use `Data.Number` ([#20](https://github.com/web/purescript-web-file/pull/20) by @JordanMartinez)
+- Update `Math` import to use `Data.Number` ([#20](https://github.com/purescript-web/purescript-web-file/pull/20) by @JordanMartinez)
 
-### purescript-web-html
+### `web-html`
 
 Breaking changes:
-- Move `getBoundingClientRect` to `purescript-web-dom` ([#73](https://github.com/web/purescript-web-html/pull/73) by @JordanMartinez)
-- Drop duplicated `set/getClassName` and `classList` ([#74](https://github.com/web/purescript-web-html/pull/74) by @JordanMartinez)
+- Move `getBoundingClientRect` to `purescript-web-dom` ([#73](https://github.com/purescript-web/purescript-web-html/pull/73) by @JordanMartinez)
+- Drop duplicated `set/getClassName` and `classList` ([#74](https://github.com/purescript-web/purescript-web-html/pull/74) by @JordanMartinez)
 
   These three entities are already defined in `purescript-web-dom`
 
 ## `purescript-node` Libraries
 
-### purescript-node-fs-aff
+### `node-fs-aff`
 
 Breaking changes:
-- Update `mkdir'` to take options arg ([#34](https://github.com/node/purescript-node-fs-aff/pull/34) by @JordanMartinez)
-- Remove `exists` since underlying `Async.exists` from `purescript-node-fs` was removed ([#61](https://github.com/purescript-node/purescript-node-fs-aff/pull/36) by @sigma-andex). Use `Sync.exists` instead.
+- Remove `exists` since the underlying `Async.exists` from `purescript-node-fs` has been removed ([#36](https://github.com/purescript-node/purescript-node-fs-aff/pull/36) by @sigma-andex)
+- Update `mkdir'` to take options arg ([#34](https://github.com/purescript-node/purescript-node-fs-aff/pull/34) by @JordanMartinez)
 
-### purescript-node-fs
+### `node-fs`
 
 Breaking changes:
-- Remove deprecated `Async.exists` ([#61](https://github.com/purescript-node/purescript-node-fs/pull/61) by @sigma-andex). Use `Sync.exists` instead.
-
-- Update `mkdir` to take an options record arg, exposing `recursive` option ([#53](https://github.com/node/purescript-node-fs/pull/53), #55, #58 by @JordanMartinez)
+- Remove `Async.exists` ([#61](https://github.com/purescript-node/purescript-node-fs/pull/61) by @sigma-andex)
+- Update `mkdir` to take an options record arg, exposing `recursive` option ([#53](https://github.com/purescript-node/purescript-node-fs/pull/53), [#55](https://github.com/purescript-node/purescript-node-fs/pull/55), [#58](https://github.com/purescript-node/purescript-node-fs/pull/58) by @JordanMartinez)
 
   To get back the old behavior of `mkdir'`, you would call `mkdir' { recursive: false, mode: mkPerms all all all }`
 
-### purescript-node-streams
+### `node-streams`
 
 Other improvements:
-- Fix `Gzip` example ([#17](https://github.com/node/purescript-node-streams/pull/17), #36 by @matthewleon and @JordanMartinez)
+- Fix `Gzip` example ([#17](https://github.com/purescript-node/purescript-node-streams/pull/17), [#36](https://github.com/purescript-node/purescript-node-streams/pull/36) by @matthewleon and @JordanMartinez)


### PR DESCRIPTION
Regenerates the changelog and makes the following changes:

All `contrib`, `web`, and `node` links that were broken are now fixed

```diff
-.../contrib/purescript-aff/pull/...
+.../purescript-contrib/purescript-aff/pull/...
```

Dropped the `purescript-` prefix on package name headers

Include changes from recent `parsing` library.

CC @thomashoneyman 