### PR TITLE
Update migration guide to account for parsing changes

### DIFF
--- a/migration-guides/0.15-Migration-Guide.md
+++ b/migration-guides/0.15-Migration-Guide.md
@@ -457,10 +457,18 @@ case foo of
       - `Text.Parsing.Parser.Combinators` -> `Parsing.Combinators`
       - `Text.Parsing.Parser.Expr` -> `Parsing.Expr`
       - `Text.Parsing.Parser.Language` -> `Parsing.Language`
-      - `Text.Parsing.Parser.Pos` -> `Parsing.Pos`
       - `Text.Parsing.Parser.String` -> `Parsing.String`
       - `Text.Parsing.Parser.String.Basic` -> `Parsing.String.Basic`
       - `Text.Parsing.Parser.Token` -> `Parsing.Token`
+  - The `Pos` module was renamed but the module itself is being deprecated (it currently re-exports `Parsing`):
+      - `Text.Parsing.Parser.Pos` -> `Parsing`
+  - The below combinators originally in the `Text.Parsing.Parser.String` module were relocated to `Parsing.String.Basic` because they are combinators, not primitive parsers:
+    - `whitespace`
+    - `skipSpaces`
+    - `oneOf`
+    - `noneOf`
+    - `oneOfCodePoints`
+    - `noneOfCodePoints`
 
 ### `groupAllBy` replaced equality function with ordering function (`purescript-lists`)
 
@@ -644,7 +652,8 @@ See [purescript-contrib/purescript-colors#44](https://github.com/purescript-cont
 - If needed immediately, copy the color scheme file into your local project
 - Consider maintaining these files as separate libraries in the community
 
-### `ParserT` got (up to) 20x performance boost (`purescript-parsing`)
+### Miscellaneous breaking change involving `purescript-parsing`
+#### `ParserT` got (up to) 20x performance boost
 
 `ParserT` now has a more efficient representation. In addition to the performance, all parser execution is always stack-safe, even monadically, obviating the need to run parsers with `Trampoline` as the base Monad or to explicitly use `MonadRec`.
 
@@ -654,6 +663,76 @@ Code that constructs parsers via the underlying representation will need to be u
 
 **To fix**:
 - Changes only needed if you depend on `ParserT`'s underlying representation
+
+### Combinator `fooRec` can be replaced with `foo` version
+
+Now that `ParserT` is stack-safe automatically, we no longer need functions that impose the `MonadRec` constraint. As such, all combinators ending in `Rec` due to the `MonadRec` constraint have been removed. The complete list is below:
+- `chainlRec` -> `chainl`
+- `chainl1Rec` -> `chainl1`
+- `chainrRec` -> `chainr`
+- `chainr1Rec` -> `chainr1`
+- `endByRec` -> `endBy`
+- `endBy1Rec` -> `endBy1`
+- `many1Rec` -> `many1`
+- `manyTillRec` -> `manyTill`
+- `manyTillRec_` -> `manyTill_`
+- `many1TillRec` -> `many1Till`
+- `many1TillRec_` -> `many1Till_`
+- `sepByRec` -> `sepBy`
+- `sepBy1Rec` -> `sepBy1`
+- `sepEndByRec` -> `sepEndBy`
+- `sepEndBy1Rec` -> `sepEndBy1`
+- `skipManyRec` -> `skipMany`
+- `skipMany1Rec` -> `skipMany1`
+
+Combinators that were defined in the module `Text.Parsing.Parser.Combinators` are now defined in `Parsing.Combinators`.
+
+**To fix:**
+- drop the `Rec` part of the combinator name and update imports
+### `MonadState` is actually usable now
+
+Previously, `ParserT`'s `MonadState` instance hardcoded the `state` type to `ParserState`. If one wanted to run the parser in the context of their own state monad, they could not do so.
+
+This limitation has been removed, enabling more powerful parsers.
+
+If you still need to get the state of the parser, you must replace `get` with `getParserT`
+
+**To fix:**
+- if depending on the underlying implementation, replace `get` with `getParserT`
+
+### `regex` now reuses the implementation from `strings`
+
+Previously, the `regex` function would use its own custom implementation. This functionality is already exposed in the `strings` package, so the function was updated to reuse that functionality:
+
+```purs
+-- old way
+foo = do
+  result <- regex { dotAll: true, global: true, ... } "finding a p[aA]ttern"
+
+-- new way
+import Data.String.Regex (dotAll, global)
+
+foo = do
+  eitherErrOrResult <- regex "finding a p[aA]ttern" (dotAll <> global)
+  case eitherErrOrResult of
+    Left e -> -- invalid regex
+    Right result -> -- usage
+```
+
+Key differences are:
+- the arguments order is swapped
+- multiple flags are specified via a `Semigroup` rather than a `Record`
+- the caller is forced to handle a possible error if the regex is invalid
+
+**To fix**:
+- use the "old way, new way" example above to update your code
+
+### `Position` now has an `index` field
+
+`index` is a line/column-independent position within the content being parsed. See the docs and implementation for more details.
+
+**To fix**:
+- If relying on this internal detail, update your code to account for it.
 
 ## Breaking Changes in the `purescript-node` libraries
 


### PR DESCRIPTION
Updates the migration guide to include the changes made in `parsing` that I wasn't previously notified of.

Part of this is pending on https://github.com/purescript-contrib/purescript-parsing/issues/190