### PR TITLE
Docs: Custom deprecation warning

### DIFF
--- a/guides/Custom-Type-Errors.md
+++ b/guides/Custom-Type-Errors.md
@@ -18,7 +18,7 @@ notBad = 21
 But now you decide there is something `better`; you want to deprecate `notBad` in favour of this new function:
 
 ```purescript
-notBad :: Warn "`notBad` is deprecated. Prefer `better` instead." => Int
+notBad :: Warn (Text "`notBad` is deprecated. Prefer `better` instead.") => Int
 notBad = 21
 
 better :: Int


### PR DESCRIPTION
Fixing example by using `Text`.
Otherwise it'll result in: "KindsDoNotUnify: Could not match kind Symbol with kind Doc."