### PR TITLE
Construct Origin with Number values

### DIFF
--- a/language/Differences-from-Haskell.md
+++ b/language/Differences-from-Haskell.md
@@ -96,7 +96,7 @@ Objects are constructed with syntax similar to that of JavaScript (and the type 
 
 ``` purescript
 origin :: PointRec 
-origin = { x: 0, y: 0 }
+origin = { x: 0.0 , y: 0.0 }
 ```
 
 And instead of introducing `x` and `y` accessor functions, `x` and `y` can be read like JavaScript properties:


### PR DESCRIPTION
Construct origin of type PointRec with Number values ( 0.0 ) to align with type definition
``` purescript
type PointRec = { x :: Number, y :: Number }
```