### PR TITLE
Fix markdownlint indentation issue

### DIFF
--- a/guides/Getting-Started.md
+++ b/guides/Getting-Started.md
@@ -1,3 +1,4 @@
+<!--markdownlint-disable MD046 -->
 # Getting Started with PureScript
 
 Let's walk through the basics of getting set up to use the PureScript compiler `purs`, and its interactive mode `purs repl`.
@@ -169,7 +170,6 @@ Now that we've seen how to use the REPL to reach the answer, let's move our solu
 
 Create a new text file `src/Euler.purs` and copy the following code:
 
-<!--markdownlint-disable MD046 -->
 ```purescript
 module Euler where
 
@@ -184,7 +184,6 @@ multiples = filter (\n -> mod n 3 == 0 || mod n 5 == 0) ns
 
 answer = sum multiples
 ```
-<!-- markdownlint-enable MD037 -->
 
 This sample illustrates a few key ideas regarding modules:
 


### PR DESCRIPTION
[MD046](https://github.com/DavidAnson/markdownlint/blob/main/doc/md046.md) wasn't closed, but instead [MD037](https://github.com/DavidAnson/markdownlint/blob/main/doc/md037.md) (mistake). This resulted in MD046 being disabled for the rest of the file. And there are indeed 4 other occurrences. Instead put the comment on top and disabled MD046 code-block-style for whole guide. This is - in my eyes - the more appropriate solution.