### PR TITLE
Update commands in Getting-Started.md to new CLI

### DIFF
--- a/guides/Getting-Started.md
+++ b/guides/Getting-Started.md
@@ -37,8 +37,7 @@ Create a new project in an empty directory using `spago init`:
 
 Your directory should now contain the following files:
 
-- `packages.dhall` - contains Spago configuration
-- `spago.dhall` - contains library dependency information
+- `spago.yaml` - contains Spago configuration and library dependency information
 - `src/Main.purs` - Entry point module for your project
 - `test/Main.purs` - An empty test suite
 
@@ -49,11 +48,19 @@ At this point, you should be able to build the project and run the tests:
 
 You should see output similar to the following:
 
-    [info] Installation complete.
-    [info] Build succeeded.
-    🍝
+    [...]
+    Building...
+               Src   Lib   All
+    Warnings     0     0     0
+    Errors       0     0     0
+
+    ✅ Build succeeded.
+
+    Running tests for package: purescript-pasta
+    🍕
     You should add some tests.
-    [info] Tests succeeded.
+
+    ✅ Test succeeded for package "purescript-pasta".
 
 If everything was built successfully, and the tests ran without problems, then the last line should state "Tests succeeded."
 
@@ -63,7 +70,7 @@ Dependencies can be installed using Spago. We will be using the `lists` and `fol
 
     spago install lists foldable-traversable
 
-The `lists` and `foldable-traversable` library sources should now be available in the `.spago/lists/{version}/` and `.spago/foldable-traversable/{version}/` subdirectories respectively, and will be included when you compile your project.
+The `lists` and `foldable-traversable` library sources should now be available in the `.spago/p/lists-{version}/` and `.spago/p/foldable-traversable-{version}/` subdirectories respectively, and will be included when you compile your project.
 
 ## Working in PSCI
 
@@ -109,11 +116,11 @@ Next, use the `:type` command, followed by a space, followed by the name of the 
 
     > import Prelude
     > :type map
-    forall a b f. Functor f => (a -> b) -> f a -> f b
+    forall (@f :: Type -> Type) (a :: Type) (b :: Type). Functor f => (a -> b) -> f a -> f b
 
     > import Data.List
     > :type zip
-    forall a b. List a -> List b -> List (Tuple a b)
+    forall (a :: Type) (b :: Type). List a -> List b -> List (Tuple a b)
 
 We will be using some of the functions from the `Prelude` and `Data.List` modules, so make sure you have imported those by using the `import` keyword:
 
@@ -255,13 +262,15 @@ The `spago run` command can be used to compile and run the `Main` module:
 
 ## Compiling for the Browser
 
-Spago can be used to turn our PureScript code into JavaScript suitable for use in the web browser by using the `spago bundle-app` command:
+Spago can be used to turn our PureScript code into JavaScript suitable for use in the web browser by using the `spago bundle` command:
 
-    $ spago bundle-app
+    $ spago bundle
+    [...]
+
       index.js  11.8kb
 
     ⚡ Done in 14ms
-    [info] Bundle succeeded and output file to index.js
+    ✅ Bundle succeeded.
 
 All the code in the `src` directory and any project dependencies have been compiled to JavaScript. The resulting code is bundled as `index.js` and has also had any unused code removed, a process known as dead code elimination. This `index.js` file can now be included in an HTML document.
 
@@ -294,7 +303,7 @@ If you open `index.js`, you should see a few compiled modules which look like th
     return n.toString();
   };
 
-  ...
+  [...]
 
   // output/Euler/index.js
   var ns = /* @__PURE__ */ function() {
@@ -336,8 +345,8 @@ Spago can also be used to generate ES modules from PureScript code. This can be 
 To build ES modules, use the `spago build` command:
 
     $ spago build
-    ...
-    Build succeeded.
+    [...]
+    ✅ Build succeeded.
 
 The generated modules will be placed in the `output` directory by default. Each PureScript module will be compiled to its own ES module, in its own subdirectory.
 


### PR DESCRIPTION
With 
```
spago --version
0.93.29
```
some commands and expected outputs have changed.
Most things are very minor, the biggest change is `spago bundle-app` became `spago bundle`