### PR TITLE
docs: correct wrong import of PS inside JS in FFI.md

### DIFF
--- a/guides/FFI.md
+++ b/guides/FFI.md
@@ -33,11 +33,11 @@ This function finds the greatest common divisor of two numbers by repeated subtr
 To understand how this function can be called from Javascript, it is important to realize that PureScript functions always get turned into Javascript functions _of a single argument_, so we need to apply its arguments one-by-one:
 
 ``` javascript
-import { gcd } from 'Test';
+import { gcd } from '../Test/index.js';
 gcd(15)(20);
 ```
 
-Here, I am assuming that the code was compiled with `psc`, which compiles PureScript modules to ES modules. For that reason, I was able to import the `gcd` function from the `Test` module.
+You may also be able to use `import { gcd } from 'Test';` construction if you compile the code with `psc`, which outputs ES modules.
 
 #### Understanding Name Generation
 


### PR DESCRIPTION
The `… from 'Test'` import doesn't work unless some additional setup is done. Presumably that's what the hint related to `psc` compiler is about, but the documentation gives no detail on such configuration as if it would Just Work™. Well, it doesn't work — what does, however, is using relative path. It works well with both `spago run` and `spago bundle-app` (barring the fact that `gcd` has name clash in Prelude).

So replace the path to make sure it works with the default setup people most likely have.